### PR TITLE
feat: Add className option for ErrorBoundaries

### DIFF
--- a/.changeset/new-pugs-smell.md
+++ b/.changeset/new-pugs-smell.md
@@ -1,0 +1,18 @@
+---
+'@data-client/react': minor
+---
+
+Add className to error boundary and errorClassName to AsyncBoundary
+
+
+```tsx
+<AsyncBoundary errorClassName="error">
+  <Stuff/>
+</AsyncBounary>
+```
+
+```tsx
+<NetworkErrorBoundary className="error">
+  <Stuff/>
+</NetworkErrorBoundary>
+```

--- a/docs/core/api/AsyncBoundary.md
+++ b/docs/core/api/AsyncBoundary.md
@@ -49,6 +49,7 @@ interface BoundaryProps {
   fallback?: React.ReactNode;
   errorComponent?: React.ComponentType<{
     error: NetworkError;
+    className?: string;
   }>;
 }
 ```
@@ -65,11 +66,21 @@ Component to handle caught errors
 
 ```tsx
 import React from 'react';
-import { CacheProvider, AsyncBoundary, NetworkError } from '@data-client/react';
+import {
+  CacheProvider,
+  AsyncBoundary,
+  NetworkError,
+} from '@data-client/react';
 
-function ErrorPage({ error }: { error: NetworkError }) {
+function ErrorPage({
+  error,
+  className,
+}: {
+  error: NetworkError;
+  className?: string;
+}) {
   return (
-    <div>
+    <div className={className}>
       {error.status} {error.response && error.response.statusText}
     </div>
   );
@@ -90,3 +101,7 @@ Note: Once `<AsyncBoundary />` catches an error it will only render the fallback
 until it is remounted. To get around this you'll likely want to place the boundary at
 locations that will cause remounts when the error should be cleared. This is usually
 below the route itself.
+
+## errorClassName
+
+`className` to forward to [errorComponent](#errorcomponent)

--- a/docs/core/api/NetworkErrorBoundary.md
+++ b/docs/core/api/NetworkErrorBoundary.md
@@ -1,5 +1,5 @@
 ---
-title: "<NetworkErrorBoundary />"
+title: '<NetworkErrorBoundary />'
 ---
 
 Displays a fallback component when a network error happens in its subtree.
@@ -13,13 +13,20 @@ Catches any error with `status` member.
 ```tsx
 interface Props {
   children: React.ReactNode;
+  className?: string;
   fallbackComponent: React.ComponentType<{
     error: NetworkError;
+    className?: string;
   }>;
 }
 export default class NetworkErrorBoundary extends React.Component<Props> {
   static defaultProps: {
-    fallbackComponent: ({ error }: { error: NetworkError }) => JSX.Element;
+    fallbackComponent: ({
+      error,
+    }: {
+      error: NetworkError;
+      className?: string;
+    }) => JSX.Element;
   };
 }
 ```
@@ -28,11 +35,21 @@ Custom fallback usage example:
 
 ```tsx
 import React from 'react';
-import { CacheProvider, NetworkErrorBoundary, NetworkError } from '@data-client/react';
+import {
+  CacheProvider,
+  NetworkErrorBoundary,
+  NetworkError,
+} from '@data-client/react';
 
-function ErrorPage({ error }: { error: NetworkError }) {
+function ErrorPage({
+  error,
+  className,
+}: {
+  error: NetworkError;
+  className?: string;
+}) {
   return (
-    <div>
+    <div className={className}>
       {error.status} {error.response && error.response.statusText}
     </div>
   );
@@ -41,7 +58,7 @@ function ErrorPage({ error }: { error: NetworkError }) {
 export default function App(): React.ReactElement {
   return (
     <CacheProvider>
-      <NetworkErrorBoundary fallbackComponent={ErrorPage}>
+      <NetworkErrorBoundary fallbackComponent={ErrorPage} className="error">
         <Router />
       </NetworkErrorBoundary>
     </CacheProvider>

--- a/packages/react/src/components/AsyncBoundary.tsx
+++ b/packages/react/src/components/AsyncBoundary.tsx
@@ -11,17 +11,24 @@ function AsyncBoundary({
   children,
   errorComponent,
   fallback,
-}: {
-  children: React.ReactNode;
-  fallback?: React.ReactNode;
-  errorComponent?: React.ComponentType<{ error: NetworkError }>;
-}): JSX.Element {
+  ...errorProps
+}: Props): JSX.Element {
   return (
     <Suspense fallback={fallback}>
-      <NetworkErrorBoundary fallbackComponent={errorComponent}>
+      <NetworkErrorBoundary {...errorProps} fallbackComponent={errorComponent}>
         {children}
       </NetworkErrorBoundary>
     </Suspense>
   );
 }
 export default memo(AsyncBoundary) as typeof AsyncBoundary;
+
+interface Props {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+  errorClassName?: string;
+  errorComponent?: React.ComponentType<{
+    error: NetworkError;
+    className?: string;
+  }>;
+}

--- a/packages/react/src/components/NetworkErrorBoundary.tsx
+++ b/packages/react/src/components/NetworkErrorBoundary.tsx
@@ -7,7 +7,8 @@ function isNetworkError(error: NetworkError | unknown): error is NetworkError {
 
 interface Props<E extends NetworkError> {
   children: React.ReactNode;
-  fallbackComponent: React.ComponentType<{ error: E }>;
+  className?: string;
+  fallbackComponent: React.ComponentType<{ error: E; className?: string }>;
 }
 interface State<E extends NetworkError> {
   error?: E;
@@ -20,8 +21,14 @@ export default class NetworkErrorBoundary<
   E extends NetworkError,
 > extends React.Component<Props<E>, State<E>> {
   static defaultProps = {
-    fallbackComponent: ({ error }: { error: NetworkError }) => (
-      <div>
+    fallbackComponent: ({
+      error,
+      className,
+    }: {
+      error: NetworkError;
+      className: string;
+    }) => (
+      <div className={className}>
         {error.status} {error.response?.statusText}
       </div>
     ),
@@ -41,6 +48,8 @@ export default class NetworkErrorBoundary<
     if (!this.state.error) {
       return this.props.children as any;
     }
-    return <this.props.fallbackComponent error={this.state.error} />;
+    const props: { error: E; className?: string } = { error: this.state.error };
+    if (this.props.className) props.className = this.props.className;
+    return <this.props.fallbackComponent {...props} />;
   }
 }

--- a/packages/react/src/components/__tests__/AsyncBoundary.web.tsx
+++ b/packages/react/src/components/__tests__/AsyncBoundary.web.tsx
@@ -57,7 +57,7 @@ describe('<AsyncBoundary />', () => {
       throw new Error('you failed');
     }
     const tree = (
-      <AsyncBoundary>
+      <AsyncBoundary errorClassName="error">
         <Throw />
         <div>hi</div>
       </AsyncBoundary>

--- a/packages/react/src/components/__tests__/NetworkErrorBoundary.web.tsx
+++ b/packages/react/src/components/__tests__/NetworkErrorBoundary.web.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { queryByAttribute, render } from '@testing-library/react';
 import React, { useContext, ReactChild, ReactNode, ReactElement } from 'react';
 
 import NetworkErrorBoundary from '../NetworkErrorBoundary';
@@ -46,14 +46,17 @@ describe('<NetworkErrorBoundary />', () => {
       throw error;
     }
     const tree = (
-      <NetworkErrorBoundary>
+      <NetworkErrorBoundary className="error">
         <Throw />
         <div>hi</div>
       </NetworkErrorBoundary>
     );
-    const { getByText, queryByText } = render(tree);
+    const { getByText, queryByText, container } = render(tree);
     expect(getByText(/500/i)).toBeDefined();
     expect(queryByText(/hi/i)).toBe(null);
+    expect(
+      (container.firstChild as any)?.classList?.contains?.('error'),
+    ).toBeTruthy();
   });
   it('should render response.statusText using default fallback', () => {
     function Throw(): ReactElement {

--- a/website/src/components/Playground/editor-types/@data-client/react.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/react.d.ts
@@ -33,20 +33,26 @@ declare namespace CacheProvider {
  * Handles loading and error conditions of Suspense
  * @see https://dataclient.io/docs/api/AsyncBoundary
  */
-declare function AsyncBoundary({ children, errorComponent, fallback, }: {
+declare function AsyncBoundary({ children, errorComponent, fallback, ...errorProps }: Props$1): JSX.Element;
+declare const _default: typeof AsyncBoundary;
+
+interface Props$1 {
     children: React$1.ReactNode;
     fallback?: React$1.ReactNode;
+    errorClassName?: string;
     errorComponent?: React$1.ComponentType<{
         error: NetworkError;
+        className?: string;
     }>;
-}): JSX.Element;
-declare const _default: typeof AsyncBoundary;
+}
 //# sourceMappingURL=AsyncBoundary.d.ts.map
 
 interface Props<E extends NetworkError> {
     children: React$1.ReactNode;
+    className?: string;
     fallbackComponent: React$1.ComponentType<{
         error: E;
+        className?: string;
     }>;
 }
 interface State<E extends NetworkError> {
@@ -58,8 +64,9 @@ interface State<E extends NetworkError> {
  */
 declare class NetworkErrorBoundary<E extends NetworkError> extends React$1.Component<Props<E>, State<E>> {
     static defaultProps: {
-        fallbackComponent: ({ error }: {
+        fallbackComponent: ({ error, className, }: {
             error: NetworkError;
+            className: string;
         }) => react_jsx_runtime.JSX.Element;
     };
     static getDerivedStateFromError(error: NetworkError | any): {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Easy style customization

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add className to [error boundary ](https://dataclient.io/docs/api/NetworkErrorBoundary)and errorClassName to [AsyncBoundary](https://dataclient.io/docs/api/AsyncBoundary)


```tsx
<AsyncBoundary errorClassName="error">
  <Stuff/>
</AsyncBounary>
```

```tsx
<NetworkErrorBoundary className="error">
  <Stuff/>
</NetworkErrorBoundary>
```