### PR TITLE
enhance: Middleware no longer gets  prop.

### DIFF
--- a/.changeset/dirty-adults-sparkle.md
+++ b/.changeset/dirty-adults-sparkle.md
@@ -1,0 +1,24 @@
+---
+'@data-client/core': minor
+---
+
+[Middleware](https://dataclient.io/docs/api/Manager#getmiddleware) no longer gets `controller` prop.
+
+The entire API is controller itself:
+`({controller}) => next => async action => {}` ->
+`(controller) => next => async action => {}`
+
+```ts
+class LoggingManager implements Manager {
+  getMiddleware = (): Middleware => controller => next => async action => {
+    console.log('before', action, controller.getState());
+    await next(action);
+    console.log('after', action, controller.getState());
+  };
+
+  cleanup() {}
+}
+```
+
+Note this has been possible for some time this simply drops
+legacy compatibility.

--- a/packages/core/src/manager/applyManager.ts
+++ b/packages/core/src/manager/applyManager.ts
@@ -8,16 +8,11 @@ export default function applyManager(
 ): Middleware[] {
   return managers.map(manager => {
     const middleware = manager.getMiddleware();
-    // TODO(breaking): remove this once controller prop is no longer supported
     return ({ dispatch, getState }) => {
       (controller as any).dispatch = dispatch;
       (controller as any).getState = getState;
-      // this is needed for backwards compatibility as we added 'controller' prop previously
-      const API = Object.create(controller, {
-        controller: { value: controller },
-      });
       // controller is a superset of the middleware API
-      return middleware(API);
+      return middleware(controller as Controller<any>);
     };
   });
 }

--- a/packages/core/src/middlewareTypes.ts
+++ b/packages/core/src/middlewareTypes.ts
@@ -4,14 +4,9 @@ import { ActionTypes, State } from './types.js';
 type RHDispatch<Actions = any> = (value: Actions) => Promise<void>;
 
 export interface MiddlewareAPI<R extends DataClientReducer = DataClientReducer>
-  extends Controller<RHDispatch<ActionTypes>> {
-  /** @deprecated use members directly instead */
-  controller: Controller<RHDispatch<ActionTypes>>;
-}
+  extends Controller<RHDispatch<ActionTypes>> {}
 export interface MiddlewareController<Actions = ActionTypes>
-  extends Controller<RHDispatch<Actions>> {
-  controller: Controller<RHDispatch<Actions>>;
-}
+  extends Controller<RHDispatch<Actions>> {}
 
 export type Middleware<Actions = any> = <
   C extends MiddlewareController<Actions>,

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -232,11 +232,8 @@ declare namespace actionTypes_d {
 
 type RHDispatch<Actions = any> = (value: Actions) => Promise<void>;
 interface MiddlewareAPI$1<R extends DataClientReducer = DataClientReducer> extends Controller<RHDispatch<ActionTypes>> {
-    /** @deprecated use members directly instead */
-    controller: Controller<RHDispatch<ActionTypes>>;
 }
 interface MiddlewareController<Actions = ActionTypes> extends Controller<RHDispatch<Actions>> {
-    controller: Controller<RHDispatch<Actions>>;
 }
 type Middleware$2<Actions = any> = <C extends MiddlewareController<Actions>>(controller: C) => (next: C['dispatch']) => C['dispatch'];
 type DataClientReducer = (prevState: State<unknown>, action: ActionTypes) => State<unknown>;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Dropping deprecations

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

[Middleware](https://dataclient.io/docs/api/Manager#getmiddleware) no longer gets `controller` prop.

The entire API is controller itself:
`({controller}) => next => async action => {}` ->
`(controller) => next => async action => {}`

```ts
class LoggingManager implements Manager {
  getMiddleware = (): Middleware => controller => next => async action => {
    console.log('before', action, controller.getState());
    await next(action);
    console.log('after', action, controller.getState());
  };

  cleanup() {}
}
```

Note this has been possible for some time this simply drops
legacy compatibility.