### PR TITLE
enhance: getPage,push,unshift,assign should not match name of parent

### DIFF
--- a/.changeset/rotten-ears-remember.md
+++ b/.changeset/rotten-ears-remember.md
@@ -1,0 +1,18 @@
+---
+'@data-client/rest': minor
+---
+
+getPage,push,unshift,assign should not match name of parent
+
+```ts
+const getTodos = new RestEndpoint({
+  urlPrefix: 'https://jsonplaceholder.typicode.com',
+  path: '/todos',
+  schema: new schema.Collection([Todo]),
+  name: 'gettodos',
+});
+
+getTodos.getPage.name === 'gettodos.getPage';
+getTodos.push.name === 'gettodos.create';
+getTodos.unshift.name === 'gettodos.create';
+```

--- a/packages/rest/src/RestEndpoint.js
+++ b/packages/rest/src/RestEndpoint.js
@@ -231,6 +231,7 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
         key(...args) {
           return sup.key.call(this, ...removeCursor(...args));
         },
+        name: this.name + '.getPage',
       });
     }
 
@@ -245,6 +246,7 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
     return this.extend({
       method: 'POST',
       schema: extractCollection(this.schema, s => s.push),
+      name: this.name + '.create',
     });
   }
 
@@ -252,6 +254,7 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
     return this.extend({
       method: 'POST',
       schema: extractCollection(this.schema, s => s.unshift),
+      name: this.name + '.create',
     });
   }
 
@@ -259,6 +262,7 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
     return this.extend({
       method: 'POST',
       schema: extractCollection(this.schema, s => s.assign),
+      name: this.name + '.create',
     });
   }
 }

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -358,6 +358,24 @@ describe('RestEndpoint', () => {
     expect(result.current.articles.map(({ id }) => id)).toEqual([5, 3, 7, 8]);
   });
 
+  it('push: should extend name of parent endpoint', () => {
+    expect(getArticleList3.push.name).toMatchSnapshot();
+    expect(getArticleList3.push.name).toBe(getArticleList3.unshift.name);
+  });
+
+  it('unshift: should extend name of parent endpoint', () => {
+    expect(getArticleList3.unshift.name).toMatchSnapshot();
+  });
+
+  // TODO: but we need a Values collection
+  // it('assign: should extend name of parent endpoint', () => {
+  //   expect(getArticleList3.assign.name).toMatchSnapshot();
+  // });
+
+  it('getPage: should extend name of parent endpoint', () => {
+    expect(getNextPage3.name).toMatchSnapshot();
+  });
+
   it('getPage: should update on get for a paginated resource with parameter in path', async () => {
     mynock.get(`/article-paginated?group=happy`).reply(200, paginatedFirstPage);
     mynock

--- a/packages/rest/src/__tests__/__snapshots__/RestEndpoint.ts.snap
+++ b/packages/rest/src/__tests__/__snapshots__/RestEndpoint.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RestEndpoint getPage: should extend name of parent endpoint 1`] = `"http://test.com/article-paginated.getPage"`;
+
+exports[`RestEndpoint push: should extend name of parent endpoint 1`] = `"http://test.com/article-paginated.create"`;
+
+exports[`RestEndpoint unshift: should extend name of parent endpoint 1`] = `"http://test.com/article-paginated.create"`;
+
 exports[`RestEndpoint.fetch() should reject if content-type does not exist with schema 1`] = `[NetworkError: Unexpected text response for schema CoolerArticle]`;
 
 exports[`RestEndpoint.fetch() should reject if content-type is not json with schema 1`] = `


### PR DESCRIPTION
### Motivation

These change the networking, so any logging system relying on names should receive a different value

### Solution

getPage,push,unshift,assign should not match name of parent

```ts
const getTodos = new RestEndpoint({
  urlPrefix: 'https://jsonplaceholder.typicode.com',
  path: '/todos',
  schema: new schema.Collection([Todo]),
  name: 'gettodos',
});

getTodos.getPage.name === 'gettodos.getPage';
getTodos.push.name === 'gettodos.create';
getTodos.unshift.name === 'gettodos.create';
```
