### PR TITLE
enhance: CacheProvider elements no longer share default managers

### DIFF
--- a/.changeset/slow-tips-cross.md
+++ b/.changeset/slow-tips-cross.md
@@ -1,0 +1,10 @@
+---
+'@data-client/react': minor
+---
+
+CacheProvider elements no longer share default managers
+
+New export: `getDefaultManagers()`
+
+BREAKING CHANGE: Newly mounted CacheProviders will have new manager
+objects when default is used

--- a/docs/core/api/CacheProvider.md
+++ b/docs/core/api/CacheProvider.md
@@ -41,7 +41,7 @@ type State<T> = Readonly<{
 Instead of starting with an empty cache, you can provide your own initial state. This can
 be useful for testing, or rehydrating the cache state when using server side rendering.
 
-### managers: Manager[] {#managers}
+### managers?: Manager[] {#managers}
 
 Default Production:
 
@@ -82,56 +82,14 @@ const RealApp = (
 
 ## defaultProps
 
-<Tabs
-defaultValue="prod"
-groupId="environment"
-values={[
-{ label: 'Production', value: 'prod' },
-{ label: 'Development', value: 'dev' },
-]}>
-<TabItem value="prod">
-
 ```ts
 import {
   defaultState,
   Controller,
-  NetworkManager,
-  SubscriptionManager,
-  PollingSubscription,
 } from '@data-client/core';
 
 CacheProvider.defaultProps = {
-  managers: [
-    new NetworkManager(),
-    new SubscriptionManager(PollingSubscription),
-  ] as Manager[],
   initialState: defaultState as State<unknown>,
   Controller,
 };
 ```
-
-</TabItem>
-<TabItem value="dev">
-
-```ts
-import {
-  defaultState,
-  Controller,
-  NetworkManager,
-  SubscriptionManager,
-  PollingSubscription,
-} from '@data-client/core';
-
-CacheProvider.defaultProps = {
-  managers: [
-    new DevToolsManager(),
-    new NetworkManager(),
-    new SubscriptionManager(PollingSubscription),
-  ] as Manager[],
-  initialState: defaultState as State<unknown>,
-  Controller,
-};
-```
-
-</TabItem>
-</Tabs>

--- a/docs/core/api/Controller.md
+++ b/docs/core/api/Controller.md
@@ -293,7 +293,7 @@ It's usually a good idea to also clear cache on 401 (unauthorized) with [LogoutM
 as well.
 
 ```ts
-import { CacheProvider, LogoutManager } from '@data-client/react';
+import { CacheProvider, LogoutManager, getDefaultManagers } from '@data-client/react';
 import ReactDOM from 'react-dom';
 import { unAuth } from '../authentication';
 
@@ -308,7 +308,7 @@ const managers = [
       controller.invalidateAll({ testKey });
     },
   }),
-  ...CacheProvider.defaultProps.managers,
+  ...getDefaultManagers(),
 ];
 
 ReactDOM.createRoot(document.body).render(

--- a/docs/core/api/LogoutManager.md
+++ b/docs/core/api/LogoutManager.md
@@ -33,11 +33,11 @@ values={[
 <TabItem value="web">
 
 ```tsx title="/index.tsx"
-import { CacheProvider, LogoutManager } from '@data-client/react';
+import { CacheProvider, LogoutManager, getDefaultManagers } from '@data-client/react';
 import ReactDOM from 'react-dom';
 
 // highlight-next-line
-const managers = [new LogoutManager(), ...CacheProvider.defaultProps.managers];
+const managers = [new LogoutManager(), ...getDefaultManagers()];
 
 ReactDOM.render(
   <CacheProvider managers={managers}>
@@ -52,11 +52,11 @@ ReactDOM.render(
 <TabItem value="18-web">
 
 ```tsx title="/index.tsx"
-import { CacheProvider, LogoutManager } from '@data-client/react';
+import { CacheProvider, LogoutManager, getDefaultManagers } from '@data-client/react';
 import ReactDOM from 'react-dom';
 
 // highlight-next-line
-const managers = [new LogoutManager(), ...CacheProvider.defaultProps.managers];
+const managers = [new LogoutManager(), ...getDefaultManagers()];
 
 ReactDOM.createRoot(document.body).render(
   <CacheProvider managers={managers}>
@@ -70,11 +70,11 @@ ReactDOM.createRoot(document.body).render(
 <TabItem value="native">
 
 ```tsx title="/index.tsx"
-import { CacheProvider, LogoutManager } from '@data-client/react';
+import { CacheProvider, LogoutManager, getDefaultManagers } from '@data-client/react';
 import { AppRegistry } from 'react-native';
 
 // highlight-next-line
-const managers = [new LogoutManager(), ...CacheProvider.defaultProps.managers];
+const managers = [new LogoutManager(), ...getDefaultManagers()];
 
 const Root = () => (
   <CacheProvider managers={managers}>
@@ -89,12 +89,12 @@ AppRegistry.registerComponent('MyApp', () => Root);
 <TabItem value="nextjs">
 
 ```tsx title="pages/_app.tsx"
-import { CacheProvider, LogoutManager } from '@data-client/react';
+import { CacheProvider, LogoutManager, getDefaultManagers } from '@data-client/react';
 import { AppCacheProvider } from '@data-client/ssr/nextjs';
 import type { AppProps } from 'next/app';
 
 // highlight-next-line
-const managers = [new LogoutManager(), ...CacheProvider.defaultProps.managers];
+const managers = [new LogoutManager(), ...getDefaultManagers()];
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
@@ -122,7 +122,7 @@ const managers = [
       controller.resetEntireStore();
     },
   }),
-  ...CacheProvider.defaultProps.managers,
+  ...getDefaultManagers(),
 ];
 ```
 
@@ -146,7 +146,7 @@ const managers = [
       controller.invalidateAll({ testKey })
     },
   }),
-  ...CacheProvider.defaultProps.managers,
+  ...getDefaultManagers(),
 ];
 ```
 

--- a/docs/core/api/Manager.md
+++ b/docs/core/api/Manager.md
@@ -86,10 +86,10 @@ values={[
 <TabItem value="web">
 
 ```tsx title="/index.tsx"
-import { CacheProvider } from '@data-client/react';
+import { CacheProvider, getDefaultManagers } from '@data-client/react';
 import ReactDOM from 'react-dom';
 
-const managers = [...CacheProvider.defaultProps.managers, new MyManager()];
+const managers = [...getDefaultManagers(), new MyManager()];
 
 ReactDOM.render(
   <CacheProvider managers={managers}>
@@ -104,10 +104,10 @@ ReactDOM.render(
 <TabItem value="18-web">
 
 ```tsx title="/index.tsx"
-import { CacheProvider } from '@data-client/react';
+import { CacheProvider, getDefaultManagers } from '@data-client/react';
 import ReactDOM from 'react-dom';
 
-const managers = [...CacheProvider.defaultProps.managers, new MyManager()];
+const managers = [...getDefaultManagers(), new MyManager()];
 
 ReactDOM.createRoot(document.body).render(
   <CacheProvider managers={managers}>
@@ -121,10 +121,10 @@ ReactDOM.createRoot(document.body).render(
 <TabItem value="native">
 
 ```tsx title="/index.tsx"
-import { CacheProvider } from '@data-client/react';
+import { CacheProvider, getDefaultManagers } from '@data-client/react';
 import { AppRegistry } from 'react-native';
 
-const managers = [...CacheProvider.defaultProps.managers, new MyManager()];
+const managers = [...getDefaultManagers(), new MyManager()];
 
 const Root = () => (
   <CacheProvider managers={managers}>
@@ -139,11 +139,11 @@ AppRegistry.registerComponent('MyApp', () => Root);
 <TabItem value="nextjs">
 
 ```tsx title="pages/_app.tsx"
-import { CacheProvider } from '@data-client/react';
+import { CacheProvider, getDefaultManagers } from '@data-client/react';
 import { AppCacheProvider } from '@data-client/ssr/nextjs';
 import type { AppProps } from 'next/app';
 
-const managers = [...CacheProvider.defaultProps.managers, new MyManager()];
+const managers = [...getDefaultManagers(), new MyManager()];
 
 export default function App({ Component, pageProps }: AppProps) {
   return (

--- a/examples/github-app/src/RootProvider.tsx
+++ b/examples/github-app/src/RootProvider.tsx
@@ -1,4 +1,9 @@
-import { CacheProvider, Controller, LogoutManager } from '@data-client/react';
+import {
+  CacheProvider,
+  Controller,
+  LogoutManager,
+  getDefaultManagers,
+} from '@data-client/react';
 import { AuthdProvider } from 'navigation/authdContext';
 import type { ReactNode } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -15,7 +20,7 @@ const managers = [
       controller.resetEntireStore();
     },
   }),
-  ...CacheProvider.defaultProps.managers,
+  ...getDefaultManagers(),
 ];
 
 export default function RootProvider({ children, ...rest }: Props) {

--- a/packages/react/src/components/__tests__/provider.native.tsx
+++ b/packages/react/src/components/__tests__/provider.native.tsx
@@ -15,7 +15,7 @@ import { Text } from 'react-native';
 import { ControllerContext, StateContext } from '../../context';
 import { useController, useSuspense } from '../../hooks';
 import { payload } from '../../test-fixtures';
-import CacheProvider from '../CacheProvider';
+import CacheProvider, { getDefaultManagers } from '../CacheProvider';
 
 const { SET_TYPE } = actionTypes;
 
@@ -158,7 +158,7 @@ describe('<CacheProvider />', () => {
   });
 
   it('should have SubscriptionManager in default managers', () => {
-    const subManagers = CacheProvider.defaultProps.managers.filter(
+    const subManagers = getDefaultManagers().filter(
       manager => manager instanceof SubscriptionManager,
     );
     expect(subManagers.length).toBe(1);

--- a/packages/react/src/components/__tests__/provider.tsx
+++ b/packages/react/src/components/__tests__/provider.tsx
@@ -16,7 +16,7 @@ import React, { useContext, Suspense, StrictMode } from 'react';
 import { ControllerContext, StateContext } from '../../context';
 import { useController, useSuspense } from '../../hooks';
 import { payload } from '../../test-fixtures';
-import CacheProvider from '../CacheProvider';
+import CacheProvider, { getDefaultManagers } from '../CacheProvider';
 
 const { SET_TYPE } = actionTypes;
 
@@ -157,7 +157,7 @@ describe('<CacheProvider />', () => {
   });
 
   it('should have SubscriptionManager in default managers', () => {
-    const subManagers = CacheProvider.defaultProps.managers.filter(
+    const subManagers = getDefaultManagers().filter(
       manager => manager instanceof SubscriptionManager,
     );
     expect(subManagers.length).toBe(1);
@@ -184,7 +184,7 @@ describe('<CacheProvider />', () => {
       }
     }
     const injector = new InjectorManager();
-    const managers = [injector, ...CacheProvider.defaultProps.managers];
+    const managers = [injector, ...getDefaultManagers()];
     let resolve: (r: any) => void = () => {};
     const endpoint = CoolerArticleResource.get.extend({
       fetch() {

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,6 +1,6 @@
 import BackupBoundary from './BackupBoundary.js';
-import CacheProvider from './CacheProvider.js';
+import CacheProvider, { getDefaultManagers } from './CacheProvider.js';
 
-export { CacheProvider, BackupBoundary };
+export { CacheProvider, BackupBoundary, getDefaultManagers };
 export { default as AsyncBoundary } from './AsyncBoundary.js';
 export { default as NetworkErrorBoundary } from './NetworkErrorBoundary.js';


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Leading towards having multiple CacheProvider instances - this is the first step. This also makes conceptualizing around managers a bit more straightforward.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
CacheProvider elements no longer share default managers

New export: `getDefaultManagers()`

BREAKING CHANGE: Newly mounted CacheProviders will have new manager
objects when default is used