### PR TITLE
enhance: Serializer schemas are only processed during denormalization

### DIFF
--- a/.changeset/tasty-gifts-shop.md
+++ b/.changeset/tasty-gifts-shop.md
@@ -1,0 +1,5 @@
+---
+'@data-client/normalizr': minor
+---
+
+BREAKING: Serializer schemas are only processed during denormalization

--- a/packages/endpoint/src/schemas/__tests__/Object.test.js
+++ b/packages/endpoint/src/schemas/__tests__/Object.test.js
@@ -62,9 +62,8 @@ describe(`${schema.Object.name} normalization`, () => {
       },
       WithOptional,
     );
-    expect(normalized.result.createdAt.getTime()).toBe(
-      normalized.result.createdAt.getTime(),
-    );
+    expect(normalized.result.createdAt).toBe(normalized.result.createdAt);
+    expect(typeof normalized.result.createdAt).toBe('string');
     expect(normalized).toMatchSnapshot();
   });
 

--- a/packages/endpoint/src/schemas/__tests__/Serializable.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Serializable.test.ts
@@ -40,7 +40,7 @@ const objectSchema = {
 };
 
 describe(`Serializable normalization`, () => {
-  test('normalizes date and custom', () => {
+  test('normalizes date and custom as passthrough', () => {
     const norm = normalize(
       {
         user: {
@@ -53,8 +53,8 @@ describe(`Serializable normalization`, () => {
       },
       objectSchema,
     );
-    expect(norm.result.time.getTime()).toBe(norm.result.time.getTime());
-    expect(norm.result.anotherItem).toBeInstanceOf(Other);
+    expect(norm.result.time).toBe(norm.result.time);
+    expect(typeof norm.result.time).toBe('string');
     expect(norm.entities[User.key]['1'].createdAt).toBe(
       norm.entities[User.key]['1'].createdAt,
     );

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -251,7 +251,7 @@ exports[`ObjectSchema normalization should deserialize Date 1`] = `
   },
   "indexes": {},
   "result": {
-    "createdAt": 2020-06-07T02:00:15.000Z,
+    "createdAt": "2020-06-07T02:00:15.000Z",
     "nextPage": "blob",
     "user": "5",
   },

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Serializable.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Serializable.test.ts.snap
@@ -28,12 +28,12 @@ exports[`Serializable denormalization denormalizes date and custom 1`] = `
 }
 `;
 
-exports[`Serializable normalization normalizes date and custom 1`] = `
+exports[`Serializable normalization normalizes date and custom as passthrough 1`] = `
 {
   "entities": {
     "User": {
       "1": {
-        "createdAt": 2020-06-07T02:00:15.000Z,
+        "createdAt": "2020-06-07T02:00:15+0000",
         "id": "1",
         "name": "Nacho",
       },
@@ -53,10 +53,10 @@ exports[`Serializable normalization normalizes date and custom 1`] = `
     "anotherItem": {
       "thing": 500,
     },
-    "time": 2020-06-07T02:00:15.000Z,
+    "time": "2020-06-07T02:00:15+0000",
     "user": "1",
   },
 }
 `;
 
-exports[`Serializable normalization normalizes date and custom 2`] = `"{"entities":{"User":{"1":{"id":"1","name":"Nacho","createdAt":"2020-06-07T02:00:15.000Z"}}},"indexes":{},"result":{"user":"1","anotherItem":{"thing":500},"time":"2020-06-07T02:00:15.000Z"},"entityMeta":{"User":{"1":{"expiresAt":null,"date":1557831718135,"fetchedAt":0}}}}"`;
+exports[`Serializable normalization normalizes date and custom as passthrough 2`] = `"{"entities":{"User":{"1":{"id":"1","name":"Nacho","createdAt":"2020-06-07T02:00:15+0000"}}},"indexes":{},"result":{"user":"1","anotherItem":{"thing":500},"time":"2020-06-07T02:00:15+0000"},"entityMeta":{"User":{"1":{"expiresAt":null,"date":1557831718135,"fetchedAt":0}}}}"`;

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -36,11 +36,6 @@ const visit = (
     );
   }
 
-  // serializable
-  if (typeof schema === 'function') {
-    return new schema(value);
-  }
-
   if (typeof value !== 'object' || typeof schema !== 'object') return value;
 
   const method = Array.isArray(schema) ? arrayNormalize : objectNormalize;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
We need absolute consistency when performing SSR and mounting the store, or we have potential for hydration mismatches.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
BREAKING: Serializer schemas are only processed during denormalization.

- This was the already the intended behavior of the [original pr for serializers](https://github.com/data-client/data-client/pull/355)
- Since then we introduced consistent caching, so there is no longer a performance benefit for running this during normalization
