### PR TITLE
enhance: Schema serializers are functions not constructors

### DIFF
--- a/.changeset/tall-swans-trade.md
+++ b/.changeset/tall-swans-trade.md
@@ -1,0 +1,48 @@
+---
+'@data-client/normalizr': minor
+'@data-client/endpoint': minor
+'@data-client/react': minor
+'@data-client/rest': minor
+---
+
+BREAKING: [Schema Serializers](https://dataclient.io/rest/guides/network-transform#deserializing-fields) *must* support function calls
+
+This means Date will no longer work like before. Possible migrations:
+
+```ts
+class Ticker extends Entity {
+  trade_id = 0;
+  price = 0;
+  time = Temporal.Instant.fromEpochSeconds(0);
+
+  pk(): string {
+    return `${this.trade_id}`;
+  }
+  static key = 'Ticker';
+
+  static schema = {
+    price: Number,
+    time: Temporal.Instant.from,
+  };
+}
+```
+
+or to continue using Date:
+
+```ts
+class Ticker extends Entity {
+  trade_id = 0;
+  price = 0;
+  time = Temporal.Instant.fromEpochSeconds(0);
+
+  pk(): string {
+    return `${this.trade_id}`;
+  }
+  static key = 'Ticker';
+
+  static schema = {
+    price: Number,
+    time: (iso:string) => new Date(iso),
+  };
+}
+```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ class Article extends Entity {
   title = '';
   body = '';
   author = User.fromJS();
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   pk() {
     return this.id;
@@ -62,7 +62,7 @@ class Article extends Entity {
 
   static schema = {
     author: User,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 }
 ```

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -1,5 +1,7 @@
+import { Temporal } from '@js-temporal/polyfill';
+import React, { createContext, useContext } from 'react';
+
 import {
-  AbstractInstanceType,
   schema,
   AbortOptimistic,
   Endpoint,
@@ -15,7 +17,6 @@ import {
   Resource,
   ResourceOptions,
 } from '@data-client/rest';
-import React, { createContext, useContext } from 'react';
 
 /** Represents data with primary key being from 'id' field. */
 export class IDEntity extends Entity {
@@ -295,11 +296,11 @@ export const ContextAuthdArticleResource = hookifyResource(
 );
 
 export class ArticleTimed extends Article {
-  readonly createdAt = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
     ...Article.schema,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 }
 export const ArticleTimedResource = createArticleResource({

--- a/docs/core/api/useDebounce.md
+++ b/docs/core/api/useDebounce.md
@@ -32,17 +32,17 @@ export class Issue extends Entity {
   state: 'open' | 'closed' = 'open';
   locked = false;
   comments = 0;
-  created_at = new Date(0);
-  updated_at = new Date(0);
-  closed_at: Date | null = null;
+  created_at = Temporal.Instant.fromEpochSeconds(0);
+  updated_at = Temporal.Instant.fromEpochSeconds(0);
+  closed_at: Temporal.Instant | null = null;
   authorAssociation = 'NONE';
   pullRequest: Record<string, any> | null = null;
   declare draft?: boolean;
 
   static schema = {
-    created_at: Date,
-    updated_at: Date,
-    closed_at: Date,
+    created_at: Temporal.Instant.from,
+    updated_at: Temporal.Instant.from,
+    closed_at: Temporal.Instant.from,
   };
 
   pk() {

--- a/docs/core/concepts/error-policy.md
+++ b/docs/core/concepts/error-policy.md
@@ -43,13 +43,13 @@ Hard errors always reject with `error` - even when data has previously made avai
 ```ts title="api/lastUpdated" collapsed
 export class TimedEntity extends Entity {
   id = '';
-  updatedAt = new Date(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
   pk() {
     return this.id;
   }
 
   static schema = {
-    updatedAt: Date,
+    updatedAt: Temporal.Instant.from,
   };
 }
 
@@ -90,7 +90,7 @@ function ShowTime() {
   return (
     <div>
       <time>
-        {Intl.DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
+        {DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
       </time>{' '}
       <div>
         <button

--- a/docs/core/concepts/expiry-policy.md
+++ b/docs/core/concepts/expiry-policy.md
@@ -19,13 +19,13 @@ To explain these concepts we'll be faking an endpoint that gives us the current 
 ```tsx title="lastUpdated"
 class TimedEntity extends Entity {
   id = '';
-  updatedAt = new Date(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
 
   pk() {
     return this.id;
   }
   static schema = {
-    updatedAt: Date,
+    updatedAt: Temporal.Instant.from,
   };
 }
 const lastUpdated = new RestEndpoint({
@@ -82,13 +82,13 @@ you will continue to see the old time without any refresh.
 ```ts title="api/lastUpdated" collapsed
 export class TimedEntity extends Entity {
   id = '';
-  updatedAt = new Date(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
 
   pk() {
     return this.id;
   }
   static schema = {
-    updatedAt: Date,
+    updatedAt: Temporal.Instant.from,
   };
 }
 
@@ -109,7 +109,7 @@ function TimePage({ id }) {
     <div>
       API Time:{' '}
       <time>
-        {Intl.DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
+        {DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
       </time>
     </div>
   );
@@ -204,13 +204,13 @@ within the expiry time it just continues to display it.
 ```ts title="api/lastUpdated" collapsed
 export class TimedEntity extends Entity {
   id = '';
-  updatedAt = new Date(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
   pk() {
     return this.id;
   }
 
   static schema = {
-    updatedAt: Date,
+    updatedAt: Temporal.Instant.from,
   };
 }
 
@@ -234,7 +234,7 @@ function TimePage({ id }) {
     <div>
       API Time:{' '}
       <time>
-        {Intl.DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
+        {DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
       </time>
     </div>
   );
@@ -293,13 +293,13 @@ the previous data. This can be done even with 'fresh' data.
 ```ts title="api/lastUpdated" collapsed
 export class TimedEntity extends Entity {
   id = '';
-  updatedAt = new Date(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
   pk() {
     return this.id;
   }
 
   static schema = {
-    updatedAt: Date,
+    updatedAt: Temporal.Instant.from,
   };
 }
 
@@ -318,7 +318,7 @@ function ShowTime() {
   return (
     <div>
       <time>
-        {Intl.DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
+        {DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
       </time>{' '}
       <button onClick={() => ctrl.fetch(lastUpdated, { id: '1' })}>
         Refresh
@@ -354,13 +354,13 @@ render(<ShowTime />);
 ```ts title="api/lastUpdated" collapsed
 export class TimedEntity extends Entity {
   id = '';
-  updatedAt = new Date(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
   pk() {
     return this.id;
   }
 
   static schema = {
-    updatedAt: Date,
+    updatedAt: Temporal.Instant.from,
   };
 }
 
@@ -380,7 +380,7 @@ export default function ShowTime({ id }: { id: string }) {
     <div>
       <b>{id}</b>{' '}
       <time>
-        {Intl.DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
+        {DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
       </time>
     </div>
   );
@@ -455,13 +455,13 @@ In this example we can see invalidating the endpoint shows the loading fallback 
 ```ts title="api/lastUpdated" collapsed
 export class TimedEntity extends Entity {
   id = '';
-  updatedAt = new Date(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
   pk() {
     return this.id;
   }
 
   static schema = {
-    updatedAt: Date,
+    updatedAt: Temporal.Instant.from,
   };
 }
 
@@ -481,7 +481,7 @@ export default function ShowTime({ id }: { id: string }) {
     <div>
       <b>{id}</b>{' '}
       <time>
-        {Intl.DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
+        {DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
       </time>
     </div>
   );
@@ -563,13 +563,13 @@ response. If the endpoint uses the entity in an Array, it will simply be removed
 ```ts title="api/lastUpdated" collapsed
 export class TimedEntity extends Entity {
   id = '';
-  updatedAt = new Date(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
   pk() {
     return this.id;
   }
 
   static schema = {
-    updatedAt: Date,
+    updatedAt: Temporal.Instant.from,
   };
 }
 
@@ -595,7 +595,7 @@ function ShowTime() {
   return (
     <div>
       <time>
-        {Intl.DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
+        {DateTimeFormat('en-US', { timeStyle: 'long' }).format(updatedAt)}
       </time>{' '}
       <button onClick={() => ctrl.fetch(deleteLastUpdated, { id: '1' })}>
         Delete

--- a/docs/core/concepts/normalization.md
+++ b/docs/core/concepts/normalization.md
@@ -157,7 +157,9 @@ import { useController } from '@data-client/react';
 export default function NewTodoForm() {
   const ctrl = useController();
   return (
-    <Form onSubmit={e => ctrl.fetch(todoCreate, new FormData(e.target))}>
+    <Form
+      onSubmit={e => ctrl.fetch(todoCreate, new FormData(e.target))}
+    >
       <FormField name="title" />
     </Form>
   );
@@ -191,7 +193,9 @@ export default function UpdateTodoForm({ id }: { id: number }) {
   const ctrl = useController();
   return (
     <Form
-      onSubmit={e => ctrl.fetch(todoUpdate, { id }, new FormData(e.target))}
+      onSubmit={e =>
+        ctrl.fetch(todoUpdate, { id }, new FormData(e.target))
+      }
       initialValues={todo}
     >
       <FormField name="title" />
@@ -350,8 +354,8 @@ class User extends Entity {
 
 ### Data Representations
 
-Additionally, any `newable` class that has a toJSON() method, can be [used as a schema](/rest/guides/network-transform#deserializing-fields). This will simply construct the object during denormalization.
-This might be useful with representations like [bignumber](https://mikemcl.github.io/bignumber.js/)
+Additionally, functions can be [used as a schema](/rest/guides/network-transform#deserializing-fields). This will be called during denormalization.
+This might be useful with representations like [bignumber](https://mikemcl.github.io/bignumber.js/) or [temporal instant](https://tc39.es/proposal-temporal/docs/instant.html)
 
 ```ts
 import { Entity } from '@data-client/endpoint';
@@ -362,7 +366,7 @@ class Todo extends Entity {
   title = '';
   completed = false;
   // highlight-next-line
-  dueDate = new Date(0);
+  dueDate = Temporal.Instant.fromEpochSeconds(0);
 
   pk() {
     return `${this.id}`;
@@ -372,7 +376,7 @@ class Todo extends Entity {
   static schema = {
     user: User,
     // highlight-next-line
-    dueDate: Date,
+    dueDate: Temporal.Instant.from,
   };
 }
 ```

--- a/docs/core/concepts/validation.md
+++ b/docs/core/concepts/validation.md
@@ -196,10 +196,10 @@ export const getArticleList = new RestEndpoint({
 
 export class ArticleFull extends ArticlePreview {
   readonly content: string = '';
-  readonly createdAt: Date = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 
   static validate(processedEntity) {
@@ -231,7 +231,7 @@ function ArticleDetail({ id, onHome }: { id: string; onHome: () => void }) {
         <div>
           Created:{' '}
           <time>
-            {Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
+            {DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
               article.createdAt,
             )}
           </time>

--- a/docs/core/shared/_useLive.mdx
+++ b/docs/core/shared/_useLive.mdx
@@ -9,7 +9,7 @@ export class Ticker extends Entity {
   trade_id = 0;
   price = 0;
   size = '0';
-  time = new Date(0);
+  time = Temporal.Instant.fromEpochSeconds(0);
   bid = '0';
   ask = '0';
   volume = '';
@@ -21,7 +21,7 @@ export class Ticker extends Entity {
 
   static schema = {
     price: Number,
-    time: Date,
+    time: Temporal.Instant.from,
   };
 }
 

--- a/docs/graphql/api/Entity.md
+++ b/docs/graphql/api/Entity.md
@@ -361,10 +361,10 @@ class User extends Entity {
 }
 class Post extends Entity {
   readonly author: User = User.fromJS({});
-  readonly createdAt: Date = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
   static schema = {
     author: User,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
   pk() {
     return this.id;
@@ -381,7 +381,7 @@ function PostPage() {
         {post.content} - <cite>{post.author.name}</cite>
       </p>
       <time>
-        {Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
+        {DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
           post.createdAt,
         )}
       </time>
@@ -401,11 +401,11 @@ considered 'optional'
 ```typescript
 class User extends Entity {
   readonly friend: User | null = null; // this field is optional
-  readonly lastUpdated: Date = new Date(0);
+  readonly lastUpdated = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
     friend: User,
-    lastUpdated: Date,
+    lastUpdated: Temporal.Instant.from,
   };
 }
 ```

--- a/docs/graphql/api/schema.Entity.md
+++ b/docs/graphql/api/schema.Entity.md
@@ -41,12 +41,12 @@ these as static members of the final class.
 ```typescript
 class User {
   username = '';
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 }
 class UserEntity extends schema.Entity(User, {
   pk: 'username',
   key: 'User',
-  schema: { createdAt: Date },
+  schema: { createdAt: Temporal.Instant.from },
 }) {}
 ```
 

--- a/docs/graphql/api/schema.md
+++ b/docs/graphql/api/schema.md
@@ -46,14 +46,14 @@ class User extends Entity {
 // Define your comments schema
 class Comment extends Entity {
   readonly id: string = '';
-  readonly createdAt: Date = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
   readonly commenter: User = User.fromJS({});
 
   pk() { return this.id; }
 
   static schema = {
     commenter: User,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   }
 }
 
@@ -129,7 +129,7 @@ Now, `normalizedData` will be:
     "comments": {
       "324": Comment {
         id: "324",
-        "createdAt": Date(`May 29, 2013`),
+        "createdAt": "2013-05-29T00:00:00-04:00",
         "commenter": "2"
       }
     }

--- a/docs/graphql/api/validateRequired.md
+++ b/docs/graphql/api/validateRequired.md
@@ -24,7 +24,7 @@ This can be useful to automatically validate for [partial results](/docs/concept
 ```ts
 class SummaryAnalysis extends Entity {
   readonly id: string = '';
-  readonly createdAt: Date = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
   readonly meanValue: number = 0;
   readonly title: string = '';
 
@@ -46,10 +46,10 @@ In case we have a field that won't always be present (like `lastRun` here), we c
 ```ts
 class FullAnalysis extends SummaryAnalysis {
   readonly graph: number[] = [];
-  readonly lastRun?: Date = new Date(0);
+  readonly lastRun? = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
-    lastRun: Date,
+    lastRun: Temporal.Instant.from,
   }
 
   static validate(processedEntity) {
@@ -83,10 +83,10 @@ In case every field of the 'full' resource was optional:
 ```ts
 class FullAnalysis extends SummaryAnalysis {
   readonly graph?: number[] = [];
-  readonly lastRun?: Date = new Date(0);
+  readonly lastRun? = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
-    lastRun: Date,
+    lastRun: Temporal.Instant.from,
   }
 
   static validate(processedEntity) {
@@ -102,10 +102,10 @@ In this case, it is best to provide a `null` default for *at least* one field.
 ```ts
 class FullAnalysis extends SummaryAnalysis {
   readonly graph: number[] = null;
-  readonly lastRun?: Date = new Date(0);
+  readonly lastRun? = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
-    lastRun: Date,
+    lastRun: Temporal.Instant.from,
   }
 
   static validate(processedEntity) {

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -61,7 +61,7 @@ export class Article extends Entity {
   content = '';
   author = User.fromJS();
   tags: string[] = [];
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   pk() {
     return this.id;
@@ -69,7 +69,7 @@ export class Article extends Entity {
 
   static schema = {
     author: User,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 
   static key = 'Article';
@@ -111,13 +111,13 @@ export class Article {
   content = '';
   author = UserEntity.fromJS();
   tags: string[] = [];
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 }
 
 export class ArticleEntity extends schema.Entity(Article, {
   schema: {
     author: UserEntity,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   },
   key: 'Article',
 }) {}

--- a/docs/rest/api/Entity.md
+++ b/docs/rest/api/Entity.md
@@ -62,7 +62,7 @@ export class Article extends Entity {
   content = '';
   author = User.fromJS();
   tags: string[] = [];
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   pk() {
     return this.id;
@@ -70,7 +70,7 @@ export class Article extends Entity {
 
   static schema = {
     author: User,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 
   static key = 'Article';
@@ -462,13 +462,13 @@ import { User } from './User';
 export class Post extends Entity {
   id = '';
   author = User.fromJS({});
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
   content = '';
   title = '';
 
   static schema = {
     author: User,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
   pk() {
     return this.id;
@@ -492,7 +492,7 @@ function PostPage() {
         {post.content} - <cite>{post.author.name}</cite>
       </p>
       <time>
-        {Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
+        {DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
           post.createdAt,
         )}
       </time>
@@ -512,11 +512,11 @@ considered 'optional'
 ```typescript
 class User extends Entity {
   readonly friend: User | null = null; // this field is optional
-  readonly lastUpdated: Date = new Date(0);
+  readonly lastUpdated = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
     friend: User,
-    lastUpdated: Date,
+    lastUpdated: Temporal.Instant.from,
   };
 }
 ```

--- a/docs/rest/api/schema.Entity.md
+++ b/docs/rest/api/schema.Entity.md
@@ -44,12 +44,12 @@ these as static members of the final class.
 ```typescript
 class User {
   username = '';
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 }
 class UserEntity extends schema.Entity(User, {
   pk: 'username',
   key: 'User',
-  schema: { createdAt: Date },
+  schema: { createdAt: Temporal.Instant.from },
 }) {}
 ```
 

--- a/docs/rest/api/schema.md
+++ b/docs/rest/api/schema.md
@@ -46,14 +46,14 @@ class User extends Entity {
 // Define your comments schema
 class Comment extends Entity {
   id = '';
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
   commenter = User.fromJS({});
 
   pk() { return this.id; }
 
   static schema = {
     commenter: User,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   }
 }
 
@@ -89,7 +89,7 @@ class Comment extends Entity {
 
   static schema = {
     commenter: User,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   }
 }
 
@@ -129,7 +129,7 @@ Now, `normalizedData` will be:
     "comments": {
       "324": Comment {
         id: "324",
-        "createdAt": Date(`May 29, 2013`),
+        "createdAt": "2013-05-29T00:00:00-04:00",
         "commenter": "2"
       }
     }

--- a/docs/rest/api/validateRequired.md
+++ b/docs/rest/api/validateRequired.md
@@ -24,7 +24,7 @@ This can be useful to automatically validate for [partial results](/docs/concept
 ```ts
 class SummaryAnalysis extends Entity {
   readonly id: string = '';
-  readonly createdAt: Date = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
   readonly meanValue: number = 0;
   readonly title: string = '';
 
@@ -46,10 +46,10 @@ In case we have a field that won't always be present (like `lastRun` here), we c
 ```ts
 class FullAnalysis extends SummaryAnalysis {
   readonly graph: number[] = [];
-  readonly lastRun?: Date = new Date(0);
+  readonly lastRun? = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
-    lastRun: Date,
+    lastRun: Temporal.Instant.from,
   }
 
   static validate(processedEntity) {
@@ -83,10 +83,10 @@ In case every field of the 'full' resource was optional:
 ```ts
 class FullAnalysis extends SummaryAnalysis {
   readonly graph?: number[] = [];
-  readonly lastRun?: Date = new Date(0);
+  readonly lastRun? = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
-    lastRun: Date,
+    lastRun: Temporal.Instant.from,
   }
 
   static validate(processedEntity) {
@@ -102,10 +102,10 @@ In this case, it is best to provide a `null` default for *at least* one field.
 ```ts
 class FullAnalysis extends SummaryAnalysis {
   readonly graph: number[] = null;
-  readonly lastRun?: Date = new Date(0);
+  readonly lastRun? = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
-    lastRun: Date,
+    lastRun: Temporal.Instant.from,
   }
 
   static validate(processedEntity) {

--- a/docs/rest/guides/computed-properties.md
+++ b/docs/rest/guides/computed-properties.md
@@ -57,7 +57,7 @@ class User extends Entity {
   id = '';
   firstName = '';
   lastName = '';
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   pk() {
     return this.id;
@@ -66,7 +66,7 @@ class User extends Entity {
 
   // highlight-start
   static schema = {
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
   // highlight-end
 }

--- a/docs/rest/guides/mocking-unfinished.md
+++ b/docs/rest/guides/mocking-unfinished.md
@@ -18,7 +18,7 @@ export class Rating extends Entity {
   id = '';
   rating = 4.6;
   author = '';
-  date = new Date(0);
+  date = Temporal.Instant.fromEpochSeconds(0);
 
   pk() {
     return this.id;
@@ -26,7 +26,7 @@ export class Rating extends Entity {
   static key = 'Rating';
 
   static schema = {
-    date: Date,
+    date: Temporal.Instant.from,
   };
 }
 
@@ -61,7 +61,7 @@ function Demo() {
         <div key={rating.pk()}>
           {rating.author}: {rating.rating}{' '}
           <time>
-            {Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
+            {DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
               rating.date,
             )}
           </time>

--- a/docs/rest/guides/network-transform.md
+++ b/docs/rest/guides/network-transform.md
@@ -83,7 +83,7 @@ import BigNumber from 'bignumber.js';
 
 export class ExchangePrice extends Entity {
   exchangePair = '';
-  updatedAt = new Date(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
   price = new BigNumber(0);
   pk() {
     return this.exchangePair;
@@ -91,7 +91,7 @@ export class ExchangePrice extends Entity {
   static key = 'ExchangePrice';
 
   static schema = {
-    updatedAt: Date,
+    updatedAt: Temporal.Instant.from,
     price: BigNumber,
   };
 }
@@ -110,7 +110,7 @@ function PricePage() {
     <div>
       ${currentPrice.price.toFormat(2)} as of{' '}
       <time>
-        {Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
+        {DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
           currentPrice.updatedAt,
         )}
       </time>

--- a/docs/rest/guides/partial-entities.md
+++ b/docs/rest/guides/partial-entities.md
@@ -82,10 +82,10 @@ export class ArticleSummary extends Entity {
 
 export class Article extends ArticleSummary {
   content = '';
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 
   static validate(processedEntity) {
@@ -124,7 +124,7 @@ function ArticleDetail({ id, onHome }: Props) {
         <div>
           Created:{' '}
           <time>
-            {Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
+            {DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
               article.createdAt,
             )}
           </time>
@@ -173,10 +173,10 @@ class ArticleSummary extends Entity {
   id = '';
   title = '';
   content = '';
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 
   pk() {

--- a/docs/rest/guides/relational-data.md
+++ b/docs/rest/guides/relational-data.md
@@ -545,14 +545,14 @@ export class User extends Entity {
   id = '';
   name = '';
   posts: Post[] = [];
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   pk() {
     return this.id;
   }
 
   static schema: Record<string, Schema | Date> = {
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 }
 ```

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -20,6 +20,7 @@
     "@data-client/core": "workspace:^",
     "@data-client/endpoint": "workspace:^",
     "@data-client/normalizr": "workspace:^",
+    "@js-temporal/polyfill": "^0.4.4",
     "benchmark": "^2.1.4",
     "normalizr": "^3.6.2",
     "react": "^18.2.0"

--- a/examples/benchmark/schemas.js
+++ b/examples/benchmark/schemas.js
@@ -1,3 +1,5 @@
+import { Temporal } from '@js-temporal/polyfill';
+
 import { Entity, schema, Query } from './dist/index.js';
 
 export class BuildTypeDescription extends Entity {
@@ -165,16 +167,16 @@ export class User extends Entity {
   publicGists = 0;
   followers = 0;
   following = 0;
-  createdAt = new Date(0);
-  updatedAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
   privateGists = 0;
   totalPrivateRepos = 0;
   ownedPrivateRepos = 0;
   collaborators = 0;
 
   static schema = {
-    createdAt: Date,
-    updatedAt: Date,
+    createdAt: Temporal.Instant.from,
+    updatedAt: Temporal.Instant.from,
   };
 
   pk() {

--- a/examples/github-app/package-lock.json
+++ b/examples/github-app/package-lock.json
@@ -15,6 +15,7 @@
         "@data-client/hooks": "^0.1.1",
         "@data-client/react": "^0.4.1",
         "@data-client/rest": "^0.7.4",
+        "@js-temporal/polyfill": "^0.4.4",
         "antd": "5.8.5",
         "parse-link-header": "^2.0.0",
         "react": "18.2.0",
@@ -4049,6 +4050,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.4.tgz",
+      "integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
+      "dependencies": {
+        "jsbi": "^4.3.0",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {
@@ -10996,6 +11009,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -17068,7 +17086,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tty-browserify": {

--- a/examples/github-app/package.json
+++ b/examples/github-app/package.json
@@ -53,6 +53,7 @@
     "@data-client/hooks": "^0.1.1",
     "@data-client/react": "^0.4.1",
     "@data-client/rest": "^0.7.4",
+    "@js-temporal/polyfill": "^0.4.4",
     "antd": "5.8.5",
     "parse-link-header": "^2.0.0",
     "react": "18.2.0",

--- a/examples/github-app/src/components/human.ts
+++ b/examples/github-app/src/components/human.ts
@@ -1,11 +1,16 @@
+import { Temporal } from '@js-temporal/polyfill';
+
 const REL = new Intl.RelativeTimeFormat(navigator.language || 'en-US', {
   localeMatcher: 'best fit',
   numeric: 'auto',
   style: 'long',
 });
 
-export function humanTime(date: Date) {
-  const seconds = Math.floor((date.getTime() - Date.now()) / 1000);
+export function humanTime(date: Temporal.Instant) {
+  const duration = date.until(Temporal.Now.instant(), {
+    largestUnit: 'second',
+  });
+  const seconds = duration.seconds;
   if (Math.abs(seconds) < 60) return REL.format(seconds, 'second');
   const minutes = Math.floor(seconds / 60);
   if (Math.abs(minutes) < 60) return REL.format(minutes, 'minute');

--- a/examples/github-app/src/pages/IssueDetail/CommentInline.tsx
+++ b/examples/github-app/src/pages/IssueDetail/CommentInline.tsx
@@ -1,6 +1,7 @@
 import { Link, useRoutes } from '@anansi/router';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { useCache, useController } from '@data-client/react';
+import { Intl } from '@js-temporal/polyfill';
 import { css } from '@linaria/core';
 import { Card, Avatar, Button, Tag, Popover } from 'antd';
 import FlexRow from 'components/FlexRow';

--- a/examples/github-app/src/pages/ProfileDetail/UserEvents.tsx
+++ b/examples/github-app/src/pages/ProfileDetail/UserEvents.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@anansi/router';
 import { BranchesOutlined, PullRequestOutlined } from '@ant-design/icons';
 import { useSuspense } from '@data-client/react';
+import { Intl } from '@js-temporal/polyfill';
 import { Timeline, Typography, Divider } from 'antd';
 import { groupBy } from 'lodash';
 import { useMemo } from 'react';

--- a/examples/github-app/src/pages/ProfileDetail/index.tsx
+++ b/examples/github-app/src/pages/ProfileDetail/index.tsx
@@ -1,4 +1,5 @@
 import { useSuspense } from '@data-client/react';
+import { Intl } from '@js-temporal/polyfill';
 import { Card, List, Layout, Typography } from 'antd';
 import Markdown from 'react-markdown';
 import { UserResource } from 'resources/User';

--- a/examples/github-app/src/resources/Comment.ts
+++ b/examples/github-app/src/resources/Comment.ts
@@ -1,3 +1,5 @@
+import { Temporal } from '@js-temporal/polyfill';
+
 import { GithubEntity, createGithubResource } from './Base';
 import { User } from './User';
 
@@ -6,8 +8,8 @@ export class Comment extends GithubEntity {
   readonly htmlUrl: string = '';
   readonly body: string = '';
   readonly user: User = User.fromJS();
-  readonly createdAt: Date = new Date(0);
-  readonly updatedAt: Date = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
+  readonly updatedAt = Temporal.Instant.fromEpochSeconds(0);
   readonly authorAssociation: string = 'NONE';
 
   get owner() {
@@ -22,8 +24,8 @@ export class Comment extends GithubEntity {
 
   static schema = {
     user: User,
-    createdAt: Date,
-    updatedAt: Date,
+    createdAt: Temporal.Instant.from,
+    updatedAt: Temporal.Instant.from,
   };
 }
 export const CommentResource = createGithubResource({

--- a/examples/github-app/src/resources/Event.tsx
+++ b/examples/github-app/src/resources/Event.tsx
@@ -6,6 +6,7 @@ import {
   PullRequestOutlined,
 } from '@ant-design/icons';
 import { schema } from '@data-client/rest';
+import { Temporal } from '@js-temporal/polyfill';
 
 import { createGithubResource, GithubEntity } from './Base';
 import { Issue } from './Issue';
@@ -20,14 +21,14 @@ export class Event extends GithubEntity {
   readonly repo: { id: number; name: string; url: string } = {} as any;
   readonly payload: Record<string, any> = {};
   readonly public: boolean = true;
-  readonly createdAt: Date = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   get icon() {
     return typeToIcon[this.type];
   }
 
   static schema = {
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 }
 export class PullRequestEvent extends Event {

--- a/examples/github-app/src/resources/Issue.tsx
+++ b/examples/github-app/src/resources/Issue.tsx
@@ -1,3 +1,5 @@
+import { Temporal } from '@js-temporal/polyfill';
+
 import { GithubEntity, createGithubResource } from './Base';
 import { Label } from './Label';
 import { stateToIcon } from './stateToIcon';
@@ -14,8 +16,8 @@ export class Issue extends GithubEntity {
   readonly state: 'open' | 'closed' = 'open';
   readonly locked: boolean = false;
   readonly comments: number = 0;
-  readonly createdAt: Date = new Date(0);
-  readonly updatedAt: Date = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
+  readonly updatedAt = Temporal.Instant.fromEpochSeconds(0);
   readonly closedAt: Date | null = null;
   readonly labels: Label[] = [];
   readonly authorAssociation: string = 'NONE';
@@ -38,9 +40,9 @@ export class Issue extends GithubEntity {
 
   static schema = {
     user: User,
-    createdAt: Date,
-    updatedAt: Date,
-    closedAt: Date,
+    createdAt: Temporal.Instant.from,
+    updatedAt: Temporal.Instant.from,
+    closedAt: Temporal.Instant.from,
     labels: [Label],
   };
 

--- a/examples/github-app/src/resources/Pull.ts
+++ b/examples/github-app/src/resources/Pull.ts
@@ -1,3 +1,5 @@
+import { Temporal } from '@js-temporal/polyfill';
+
 import { GithubEntity, createGithubResource } from './Base';
 import { Label } from './Label';
 import { stateToIcon } from './stateToIcon';
@@ -17,8 +19,8 @@ export class Pull extends GithubEntity {
   body = '';
   labels: Label[] = [];
   activeLockReason = '';
-  createdAt = new Date(0);
-  updatedAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
+  updatedAt = Temporal.Instant.fromEpochSeconds(0);
   closedAt: Date | null = null;
   authorAssociation = 'OWNER';
   autoMerge: null | boolean = null;
@@ -40,9 +42,9 @@ export class Pull extends GithubEntity {
 
   static schema = {
     user: User,
-    createdAt: Date,
-    updatedAt: Date,
-    closedAt: Date,
+    createdAt: Temporal.Instant.from,
+    updatedAt: Temporal.Instant.from,
+    closedAt: Temporal.Instant.from,
     labels: [Label],
   };
 

--- a/examples/github-app/src/resources/Reaction.tsx
+++ b/examples/github-app/src/resources/Reaction.tsx
@@ -1,4 +1,5 @@
 import { HeartOutlined } from '@ant-design/icons';
+import { Temporal } from '@js-temporal/polyfill';
 
 import { createGithubResource, GithubEntity } from './Base';
 import PreviewEndpoint from './PreviewEndpoint';
@@ -7,7 +8,7 @@ import { User } from './User';
 export class Reaction extends GithubEntity {
   readonly user: User = User.fromJS();
   readonly content: ReactionType = '+1';
-  readonly createdAt: Date = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   get contentIcon() {
     return contentToIcon[this.content];
@@ -19,7 +20,7 @@ export class Reaction extends GithubEntity {
 
   static schema = {
     user: User,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 }
 

--- a/examples/github-app/src/resources/Repository.tsx
+++ b/examples/github-app/src/resources/Repository.tsx
@@ -1,3 +1,5 @@
+import { Temporal } from '@js-temporal/polyfill';
+
 import { GithubEntity, createGithubResource, GithubGqlEndpoint } from './Base';
 
 export class Repository extends GithubEntity {
@@ -24,16 +26,16 @@ export class Repository extends GithubEntity {
   readonly archived: boolean = false;
   readonly disabled: boolean = false;
   readonly visibility: 'public' | 'private' = 'public';
-  readonly pushedAt: Date = new Date(0);
-  readonly createdAt: Date = new Date(0);
-  readonly updatedAt: Date = new Date(0);
+  readonly pushedAt = Temporal.Instant.fromEpochSeconds(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
+  readonly updatedAt = Temporal.Instant.fromEpochSeconds(0);
   readonly templateRepository: null = null;
   readonly owner: { login: string } = { login: '' };
 
   static schema = {
-    pushedAt: Date,
-    createdAt: Date,
-    updatedAt: Date,
+    pushedAt: Temporal.Instant.from,
+    createdAt: Temporal.Instant.from,
+    updatedAt: Temporal.Instant.from,
   };
 
   pk() {

--- a/examples/github-app/src/resources/Review.ts
+++ b/examples/github-app/src/resources/Review.ts
@@ -1,3 +1,5 @@
+import { Temporal } from '@js-temporal/polyfill';
+
 import { GithubEntity } from './Base';
 
 export class Review extends GithubEntity {
@@ -10,9 +12,9 @@ export class Review extends GithubEntity {
   pullRequestUrl = '';
 
   state = 'approved';
-  submittedAt = new Date(0);
+  submittedAt = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
-    submittedAt: Date,
+    submittedAt: Temporal.Instant.from,
   };
 }

--- a/examples/github-app/src/resources/User.ts
+++ b/examples/github-app/src/resources/User.ts
@@ -1,3 +1,5 @@
+import { Temporal } from '@js-temporal/polyfill';
+
 import { createGithubResource, GithubEndpoint, GithubEntity } from './Base';
 
 export class User extends GithubEntity {
@@ -29,16 +31,16 @@ export class User extends GithubEntity {
   readonly publicGists: number = 0;
   readonly followers: number = 0;
   readonly following: number = 0;
-  readonly createdAt: Date = new Date(0);
-  readonly updatedAt: Date = new Date(0);
+  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
+  readonly updatedAt = Temporal.Instant.fromEpochSeconds(0);
   readonly privateGists: number = 0;
   readonly totalPrivateRepos: number = 0;
   readonly ownedPrivateRepos: number = 0;
   readonly collaborators: number = 0;
 
   static schema = {
-    createdAt: Date,
-    updatedAt: Date,
+    createdAt: Temporal.Instant.from,
+    updatedAt: Temporal.Instant.from,
   };
 
   pk() {

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -13,6 +13,7 @@
         "@data-client/rest": "^0.7.4",
         "@data-client/ssr": "^0.2.1",
         "@data-client/test": "^0.3.1",
+        "@js-temporal/polyfill": "^0.4.4",
         "@types/node": "20.5.7",
         "@types/react": "18.2.21",
         "@types/react-dom": "18.2.7",
@@ -2495,6 +2496,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.4.tgz",
+      "integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
+      "dependencies": {
+        "jsbi": "^4.3.0",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@next/env": {
@@ -5508,6 +5521,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
     },
     "node_modules/jsc-android": {
       "version": "250231.0.0",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -14,6 +14,7 @@
     "@data-client/rest": "^0.7.4",
     "@data-client/ssr": "^0.2.1",
     "@data-client/test": "^0.3.1",
+    "@js-temporal/polyfill": "^0.4.4",
     "@types/node": "20.5.7",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",

--- a/examples/nextjs/resources/Ticker.ts
+++ b/examples/nextjs/resources/Ticker.ts
@@ -1,12 +1,13 @@
 import { Entity, RestEndpoint } from '@data-client/rest';
 import type { FixtureEndpoint } from '@data-client/test';
+import { Temporal } from '@js-temporal/polyfill';
 
 // Visit https://dataclient.io/docs/guides/resource-types to read more about these definitions
 export class Ticker extends Entity {
   trade_id = 0;
   price = 0;
   size = '0';
-  time = new Date(0);
+  time = Temporal.Instant.fromEpochSeconds(0);
   bid = '0';
   ask = '0';
   volume = '';
@@ -21,7 +22,13 @@ export class Ticker extends Entity {
   // see https://dataclient.io/rest/api/Entity#schema
   static schema = {
     price: Number,
-    time: Date,
+    _time: Temporal.Instant.from,
+    get time() {
+      return this._time;
+    },
+    set time(value) {
+      this._time = value;
+    },
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@commitlint/config-conventional": "17.7.0",
     "@data-client/react": "workspace:^",
     "@data-client/test": "workspace:^",
+    "@js-temporal/polyfill": "^0.4.4",
     "@react-navigation/native": "^6.0.13",
     "@react-navigation/native-stack": "^6.9.1",
     "@testing-library/react": "14.0.0",

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -120,6 +120,7 @@
   },
   "devDependencies": {
     "@anansi/browserslist-config": "^1.4.2",
+    "@js-temporal/polyfill": "^0.4.4",
     "@types/node": "^20.0.0"
   }
 }

--- a/packages/endpoint/src/__tests__/validateRequired.test.ts
+++ b/packages/endpoint/src/__tests__/validateRequired.test.ts
@@ -1,4 +1,5 @@
 // eslint-env jest
+import { Temporal } from '@js-temporal/polyfill';
 import { IDEntity } from '__tests__/new';
 
 import denormalize from '../schemas/__tests__/denormalize';
@@ -38,13 +39,13 @@ class Tacos extends IDEntity {
 class MyEntity extends Entity {
   readonly name: string = '';
   readonly secondthing: string = '';
-  readonly blarb?: Date = new Date(0);
+  blarb = Temporal.Instant.fromEpochSeconds(0);
   pk() {
     return this.name;
   }
 
   static schema = {
-    blarb: Date,
+    blarb: Temporal.Instant.from,
   };
 
   static validate(processedEntity: any): string | undefined {
@@ -62,7 +63,7 @@ describe(`validateRequired`, () => {
       }),
     ).toMatchInlineSnapshot(`
       MyEntity {
-        "blarb": 1970-01-01T00:00:00.000Z,
+        "blarb": "1970-01-01T00:00:00Z",
         "name": "bob",
         "secondthing": "hi",
       }
@@ -83,7 +84,7 @@ describe(`validateRequired`, () => {
       }),
     ).toMatchInlineSnapshot(`
       MyEntity {
-        "blarb": 1970-01-01T00:01:40.000Z,
+        "blarb": "1970-01-01T00:01:40Z",
         "name": "bob",
         "secondthing": "hi",
       }

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -12,9 +12,7 @@ export type Schema =
 
 export type Serializable<
   T extends { toJSON(): string } = { toJSON(): string },
-> = {
-  prototype: T;
-};
+> = (value: any) => T;
 
 export interface SchemaSimple<T = any> {
   normalize(

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -1,6 +1,7 @@
 // eslint-env jest
 import { inferResults, normalize, WeakEntityMap } from '@data-client/normalizr';
 import { INVALID } from '@data-client/normalizr';
+import { Temporal } from '@js-temporal/polyfill';
 import { IDEntity } from '__tests__/new';
 import { fromJS, Record } from 'immutable';
 
@@ -148,7 +149,7 @@ describe(`${Entity.name} normalization`, () => {
       }
 
       static schema = {
-        blarb: Date,
+        blarb: Temporal.Instant.from,
       };
     }
     const schema = MyEntity;
@@ -168,7 +169,7 @@ describe(`${Entity.name} normalization`, () => {
       }
 
       static schema = {
-        blarb: Date,
+        blarb: Temporal.Instant.from,
       };
     }
     const schema = MyEntity;
@@ -858,7 +859,7 @@ describe.each([
         }
 
         static schema = {
-          blarb: Date,
+          blarb: Temporal.Instant.from,
         };
       }
       const schema = MyEntity;
@@ -886,7 +887,7 @@ describe.each([
         }
 
         static schema = {
-          blarb: Date,
+          blarb: Temporal.Instant.from,
         };
       }
       const schema = MyEntity;
@@ -1330,10 +1331,10 @@ describe('Entity.defaults', () => {
     }
     class UserEntity extends ID {
       username = '';
-      createdAt = new Date(0);
+      createdAt = Temporal.Instant.fromEpochSeconds(0);
 
       static schema = {
-        createdAt: Date,
+        createdAt: Temporal.Instant.from,
       };
     }
 
@@ -1344,7 +1345,7 @@ describe('Entity.defaults', () => {
     `);
     expect(UserEntity.getMyDefaults()).toMatchInlineSnapshot(`
       UserEntity {
-        "createdAt": 1970-01-01T00:00:00.000Z,
+        "createdAt": "1970-01-01T00:00:00Z",
         "id": "",
         "username": "",
       }

--- a/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
@@ -1,6 +1,7 @@
 // eslint-env jest
 import { normalize, WeakEntityMap } from '@data-client/normalizr';
 import { INVALID } from '@data-client/normalizr';
+import { Temporal } from '@js-temporal/polyfill';
 import { fromJS, Record } from 'immutable';
 
 import { denormalizeSimple } from './denormalize';
@@ -240,56 +241,56 @@ describe(`${schema.Entity.name} construction`, () => {
         id = '';
         username = '';
         title = '';
-        createdAt = new Date(0);
+        createdAt = Temporal.Instant.fromEpochSeconds(0);
       }
       class MyEntity extends schema.Entity(MyData, {
-        schema: { createdAt: Date },
+        schema: { createdAt: Temporal.Instant.from },
       }) {}
-      expect(MyEntity.schema).toEqual({ createdAt: Date });
+      expect(MyEntity.schema).toEqual({ createdAt: Temporal.Instant.from });
     });
     it('options.schema should override base schema', () => {
       class MyData {
         id = '';
         username = '';
         title = '';
-        createdAt = new Date(0);
+        createdAt = Temporal.Instant.fromEpochSeconds(0);
         static schema = {
-          user: Date,
+          user: Temporal.Instant.from,
         };
       }
       class MyEntity extends schema.Entity(MyData, {
-        schema: { createdAt: Date },
+        schema: { createdAt: Temporal.Instant.from },
       }) {}
-      expect(MyEntity.schema).toEqual({ createdAt: Date });
+      expect(MyEntity.schema).toEqual({ createdAt: Temporal.Instant.from });
     });
     it('static schema in base should be used', () => {
       class MyData {
         id = '';
         username = '';
         title = '';
-        createdAt = new Date(0);
+        createdAt = Temporal.Instant.fromEpochSeconds(0);
         static schema = {
-          createdAt: Date,
+          createdAt: Temporal.Instant.from,
         };
       }
       class MyEntity extends schema.Entity(MyData) {}
-      expect(MyEntity.schema).toEqual({ createdAt: Date });
+      expect(MyEntity.schema).toEqual({ createdAt: Temporal.Instant.from });
     });
     it('static schema in Entity should override options', () => {
       class MyData {
         id = '';
         username = '';
         title = '';
-        createdAt = new Date(0);
+        createdAt = Temporal.Instant.fromEpochSeconds(0);
       }
       class MyEntity extends schema.Entity(MyData, {
-        schema: { createdAt: Date },
+        schema: { createdAt: Temporal.Instant.from },
       }) {
         static schema = {
-          user: Date,
+          user: Temporal.Instant.from,
         };
       }
-      expect(MyEntity.schema).toEqual({ user: Date });
+      expect(MyEntity.schema).toEqual({ user: Temporal.Instant.from });
     });
   });
 });
@@ -379,7 +380,7 @@ describe(`${schema.Entity.name} normalization`, () => {
     const MyEntity = schema.Entity(MyData, {
       pk: 'name',
       schema: {
-        blarb: Date,
+        blarb: Temporal.Instant.from,
       },
     });
 
@@ -398,7 +399,7 @@ describe(`${schema.Entity.name} normalization`, () => {
     class MyEntity extends schema.Entity(MyData, {
       pk: 'name',
       schema: {
-        blarb: Date,
+        blarb: Temporal.Instant.from,
       },
     }) {}
 
@@ -887,7 +888,7 @@ describe.each([
       }
       class MyEntity extends schema.Entity(MyData, {
         pk: 'name',
-        schema: { blarb: Date },
+        schema: { blarb: Temporal.Instant.from },
       }) {}
 
       expect(
@@ -911,7 +912,7 @@ describe.each([
       }
       class MyEntity extends schema.Entity(MyData, {
         pk: 'name',
-        schema: { blarb: Date },
+        schema: { blarb: Temporal.Instant.from },
       }) {}
 
       expect(
@@ -1360,10 +1361,10 @@ describe('Entity.defaults', () => {
     }
     class UserEntity extends ID {
       username = '';
-      createdAt = new Date(0);
+      createdAt = Temporal.Instant.fromEpochSeconds(0);
 
       static schema = {
-        createdAt: Date,
+        createdAt: Temporal.Instant.from,
       };
     }
 
@@ -1374,7 +1375,7 @@ describe('Entity.defaults', () => {
     `);
     expect(UserEntity.getMyDefaults()).toMatchInlineSnapshot(`
       UserEntity {
-        "createdAt": 1970-01-01T00:00:00.000Z,
+        "createdAt": "1970-01-01T00:00:00Z",
         "id": "",
         "username": "",
       }

--- a/packages/endpoint/src/schemas/__tests__/Object.test.js
+++ b/packages/endpoint/src/schemas/__tests__/Object.test.js
@@ -1,5 +1,6 @@
 // eslint-env jest
 import { normalize } from '@data-client/normalizr';
+import { Temporal } from '@js-temporal/polyfill';
 import { IDEntity } from '__tests__/new';
 import { fromJS } from 'immutable';
 
@@ -52,7 +53,7 @@ describe(`${schema.Object.name} normalization`, () => {
     const WithOptional = new schema.Object({
       user: User,
       nextPage: '',
-      createdAt: Date,
+      createdAt: Temporal.Instant.from,
     });
     const normalized = normalize(
       {
@@ -72,7 +73,7 @@ describe(`${schema.Object.name} normalization`, () => {
     const WithOptional = new schema.Object({
       user: User,
       nextPage: '',
-      createdAt: Date,
+      createdAt: Temporal.Instant.from,
     });
     const normalized = normalize(
       {

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Serializable.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Serializable.test.ts.snap
@@ -3,11 +3,12 @@
 exports[`Serializable denormalization denormalizes as plain 1`] = `
 {
   "anotherItem": {
+    "defaulted": 0,
     "thing": 500,
   },
-  "time": 2020-06-07T02:00:15.000Z,
+  "time": "2020-06-07T02:00:15Z",
   "user": User {
-    "createdAt": 2020-06-07T02:00:15.000Z,
+    "createdAt": "2020-06-07T02:00:15Z",
     "id": "1",
     "name": "Nacho",
   },
@@ -17,11 +18,12 @@ exports[`Serializable denormalization denormalizes as plain 1`] = `
 exports[`Serializable denormalization denormalizes date and custom 1`] = `
 {
   "anotherItem": {
+    "defaulted": 0,
     "thing": 500,
   },
-  "time": 2020-06-07T02:00:15.000Z,
+  "time": "2020-06-07T02:00:15Z",
   "user": User {
-    "createdAt": 2020-06-07T02:00:15.000Z,
+    "createdAt": "2020-06-07T02:00:15Z",
     "id": "1",
     "name": "Nacho",
   },

--- a/packages/normalizr/src/__tests__/WeakEntityMap.test.ts
+++ b/packages/normalizr/src/__tests__/WeakEntityMap.test.ts
@@ -1,9 +1,11 @@
+import { Temporal } from '@js-temporal/polyfill';
+
 import WeakEntityMap, { getEntities } from '../WeakEntityMap';
 
 describe('WeakEntityMap', () => {
   const a = { hi: '5' };
   const b = [1, 2, 3];
-  const c = new Date(0);
+  const c = Temporal.Instant.fromEpochSeconds(0);
   const state: Record<string, Record<string, object>> = {
     A: {
       '1': a,

--- a/packages/normalizr/src/denormalize/unvisit.ts
+++ b/packages/normalizr/src/denormalize/unvisit.ts
@@ -100,11 +100,10 @@ const getUnvisit = (
 
     const hasDenormalize = typeof schema.denormalize === 'function';
 
-    // deserialize fields (like Date)
+    // deserialize fields (like Temporal.Instant)
     if (!hasDenormalize && typeof schema === 'function') {
-      if (input instanceof schema) return input;
       if (input === undefined) return input;
-      return new schema(input);
+      return schema(input);
     }
 
     if (input === undefined) {

--- a/packages/normalizr/src/interface.ts
+++ b/packages/normalizr/src/interface.ts
@@ -8,9 +8,7 @@ export type Schema =
 
 export type Serializable<
   T extends { toJSON(): string } = { toJSON(): string },
-> = {
-  prototype: T;
-};
+> = (value: any) => T;
 
 export interface SchemaSimple<T = any> {
   normalize(

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -48,7 +48,7 @@ class Article extends Entity {
   title = '';
   body = '';
   author = User.fromJS();
-  createdAt = new Date(0);
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   pk() {
     return this.id;
@@ -56,7 +56,7 @@ class Article extends Entity {
 
   static schema = {
     author: User,
-    createdAt: Date,
+    createdAt: Temporal.Instant.from,
   };
 }
 ```

--- a/packages/react/src/hooks/__tests__/useSuspense.native.tsx
+++ b/packages/react/src/hooks/__tests__/useSuspense.native.tsx
@@ -10,6 +10,7 @@ import { Endpoint, FetchFunction, ReadEndpoint } from '@data-client/endpoint';
 import { normalize } from '@data-client/normalizr';
 import { makeRenderDataClient, mockInitialState } from '@data-client/test';
 import { jest } from '@jest/globals';
+import { Temporal } from '@js-temporal/polyfill';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { render, act, screen } from '@testing-library/react-native';
@@ -30,10 +31,10 @@ import { createEntityMeta } from '__tests__/utils';
 import { SpyInstance } from 'jest-mock';
 import nock from 'nock';
 import React, { Suspense } from 'react';
-// relative imports to avoid circular dependency in tsconfig references
 import { Text, View } from 'react-native';
 import { InteractionManager } from 'react-native';
 
+// relative imports to avoid circular dependency in tsconfig references
 import {
   CacheProvider,
   useController,
@@ -565,11 +566,11 @@ describe('useSuspense()', () => {
     // undefined means it threw
     expect(result.current).toBeUndefined();
     await waitForNextUpdate();
-    expect(result.current.createdAt.getDate()).toBe(
-      result.current.createdAt.getDate(),
-    );
+    expect(
+      result.current.createdAt.equals(result.current.createdAt),
+    ).toBeTruthy();
     expect(result.current.createdAt).toEqual(
-      new Date('2020-06-07T02:00:15+0000'),
+      Temporal.Instant.from('2020-06-07T02:00:15+0000'),
     );
     expect(result.current.id).toEqual(payload.id);
     expect(result.current).toBeInstanceOf(ArticleTimed);

--- a/packages/react/src/hooks/__tests__/useSuspense.web.tsx
+++ b/packages/react/src/hooks/__tests__/useSuspense.web.tsx
@@ -9,6 +9,7 @@ import { FetchAction } from '@data-client/core';
 import { Endpoint, FetchFunction, ReadEndpoint } from '@data-client/endpoint';
 import { normalize } from '@data-client/normalizr';
 import { jest } from '@jest/globals';
+import { Temporal } from '@js-temporal/polyfill';
 import { render, act } from '@testing-library/react';
 import {
   CoolerArticleResource,
@@ -29,8 +30,8 @@ import { createEntityMeta } from '__tests__/utils';
 import { SpyInstance } from 'jest-mock';
 import nock from 'nock';
 import React, { Suspense } from 'react';
-// relative imports to avoid circular dependency in tsconfig references
 
+// relative imports to avoid circular dependency in tsconfig references
 import {
   CacheProvider,
   useController,
@@ -543,11 +544,11 @@ describe('useSuspense()', () => {
     // undefined means it threw
     expect(result.current).toBeUndefined();
     await waitForNextUpdate();
-    expect(result.current.createdAt.getDate()).toBe(
-      result.current.createdAt.getDate(),
-    );
+    expect(
+      result.current.createdAt.equals(result.current.createdAt),
+    ).toBeTruthy();
     expect(result.current.createdAt).toEqual(
-      new Date('2020-06-07T02:00:15+0000'),
+      Temporal.Instant.from('2020-06-07T02:00:15+0000'),
     );
     expect(result.current.id).toEqual(payload.id);
     expect(result.current).toBeInstanceOf(ArticleTimed);

--- a/website/package.json
+++ b/website/package.json
@@ -42,6 +42,7 @@
     "@docusaurus/preset-classic": "canary",
     "@docusaurus/theme-live-codeblock": "canary",
     "@docusaurus/theme-mermaid": "canary",
+    "@js-temporal/polyfill": "^0.4.4",
     "@monaco-editor/react": "^4.4.6",
     "bignumber.js": "9.1.2",
     "classnames": "^2.3.2",

--- a/website/src/components/Demo/code/live-app/polling/resources.ts
+++ b/website/src/components/Demo/code/live-app/polling/resources.ts
@@ -4,7 +4,7 @@ export class Ticker extends Entity {
   trade_id = 0;
   price = 0;
   size = '0';
-  time = new Date(0);
+  time = Temporal.Instant.fromEpochSeconds(0);
   bid = '0';
   ask = '0';
   volume = '';
@@ -17,7 +17,7 @@ export class Ticker extends Entity {
 
   static schema = {
     price: Number,
-    time: Date,
+    time: Temporal.Instant.from,
   };
 }
 

--- a/website/src/components/Playground/PreviewWithScope.tsx
+++ b/website/src/components/Playground/PreviewWithScope.tsx
@@ -2,8 +2,8 @@ import * as graphql from '@data-client/graphql';
 import * as hooks from '@data-client/hooks';
 import * as rhReact from '@data-client/react';
 import * as rest from '@data-client/rest';
-import * as restNext from '@data-client/rest/next';
 import type { Fixture, Interceptor } from '@data-client/test';
+import { Temporal, Intl as PolyIntl } from '@js-temporal/polyfill';
 import BigNumber from 'bignumber.js';
 import React from 'react';
 import { LiveProvider } from 'react-live';
@@ -30,10 +30,14 @@ const mockFetch = (getResponse, name, delay = 150) => {
   return fetch;
 };
 
+const Intl = {
+  ...globalThis.Intl,
+  ...PolyIntl,
+};
+
 const scope = {
   ...rhReact,
   ...rest,
-  ...restNext,
   ...graphql,
   ...hooks,
   uuid,
@@ -41,6 +45,9 @@ const scope = {
   mockFetch,
   BigNumber,
   ResetableErrorBoundary,
+  Temporal,
+  Intl,
+  DateTimeFormat: PolyIntl.DateTimeFormat,
   ...designSystem,
 };
 

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -5,9 +5,7 @@ type Serializable<T extends {
     toJSON(): string;
 } = {
     toJSON(): string;
-}> = {
-    prototype: T;
-};
+}> = (value: any) => T;
 interface SchemaSimple<T = any> {
     normalize(input: any, parent: any, key: any, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities?: any, args?: any[]): any;
     denormalize(input: {}, args: any, unvisit: (input: any, schema: any) => any): T;

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -103,9 +103,7 @@ type Serializable<T extends {
     toJSON(): string;
 } = {
     toJSON(): string;
-}> = {
-    prototype: T;
-};
+}> = (value: any) => T;
 interface SchemaSimple<T = any> {
     normalize(input: any, parent: any, key: any, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: any, args?: any[]): any;
     denormalize(input: {}, args: readonly any[], unvisit: (input: any, schema: any) => any): T;

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -103,9 +103,7 @@ type Serializable<T extends {
     toJSON(): string;
 } = {
     toJSON(): string;
-}> = {
-    prototype: T;
-};
+}> = (value: any) => T;
 interface SchemaSimple<T = any> {
     normalize(input: any, parent: any, key: any, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: any, args?: any[]): any;
     denormalize(input: {}, args: readonly any[], unvisit: (input: any, schema: any) => any): T;

--- a/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
@@ -5,9 +5,7 @@ type Serializable<T extends {
     toJSON(): string;
 } = {
     toJSON(): string;
-}> = {
-    prototype: T;
-};
+}> = (value: any) => T;
 interface SchemaSimple<T = any> {
     normalize(input: any, parent: any, key: any, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities?: any, args?: any[]): any;
     denormalize(input: {}, args: any, unvisit: (input: any, schema: any) => any): T;

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -103,9 +103,7 @@ type Serializable<T extends {
     toJSON(): string;
 } = {
     toJSON(): string;
-}> = {
-    prototype: T;
-};
+}> = (value: any) => T;
 interface SchemaSimple<T = any> {
     normalize(input: any, parent: any, key: any, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: any, args?: any[]): any;
     denormalize(input: {}, args: readonly any[], unvisit: (input: any, schema: any) => any): T;

--- a/website/src/components/Playground/editor-types/temporal.d.ts
+++ b/website/src/components/Playground/editor-types/temporal.d.ts
@@ -1,0 +1,2127 @@
+export namespace Temporal {
+  export type ComparisonResult = -1 | 0 | 1;
+  export type RoundingMode =
+    | 'ceil'
+    | 'floor'
+    | 'expand'
+    | 'trunc'
+    | 'halfCeil'
+    | 'halfFloor'
+    | 'halfExpand'
+    | 'halfTrunc'
+    | 'halfEven';
+
+  /**
+   * Options for assigning fields using `with()` or entire objects with
+   * `from()`.
+   * */
+  export type AssignmentOptions = {
+    /**
+     * How to deal with out-of-range values
+     *
+     * - In `'constrain'` mode, out-of-range values are clamped to the nearest
+     *   in-range value.
+     * - In `'reject'` mode, out-of-range values will cause the function to
+     *   throw a RangeError.
+     *
+     * The default is `'constrain'`.
+     */
+    overflow?: 'constrain' | 'reject';
+  };
+
+  /**
+   * Options for assigning fields using `Duration.prototype.with()` or entire
+   * objects with `Duration.from()`, and for arithmetic with
+   * `Duration.prototype.add()` and `Duration.prototype.subtract()`.
+   * */
+  export type DurationOptions = {
+    /**
+     * How to deal with out-of-range values
+     *
+     * - In `'constrain'` mode, out-of-range values are clamped to the nearest
+     *   in-range value.
+     * - In `'balance'` mode, out-of-range values are resolved by balancing them
+     *   with the next highest unit.
+     *
+     * The default is `'constrain'`.
+     */
+    overflow?: 'constrain' | 'balance';
+  };
+
+  /**
+   * Options for conversions of `Temporal.PlainDateTime` to `Temporal.Instant`
+   * */
+  export type ToInstantOptions = {
+    /**
+     * Controls handling of invalid or ambiguous times caused by time zone
+     * offset changes like Daylight Saving time (DST) transitions.
+     *
+     * This option is only relevant if a `DateTime` value does not exist in the
+     * destination time zone (e.g. near "Spring Forward" DST transitions), or
+     * exists more than once (e.g. near "Fall Back" DST transitions).
+     *
+     * In case of ambiguous or non-existent times, this option controls what
+     * exact time to return:
+     * - `'compatible'`: Equivalent to `'earlier'` for backward transitions like
+     *   the start of DST in the Spring, and `'later'` for forward transitions
+     *   like the end of DST in the Fall. This matches the behavior of legacy
+     *   `Date`, of libraries like moment.js, Luxon, or date-fns, and of
+     *   cross-platform standards like [RFC 5545
+     *   (iCalendar)](https://tools.ietf.org/html/rfc5545).
+     * - `'earlier'`: The earlier time of two possible times
+     * - `'later'`: The later of two possible times
+     * - `'reject'`: Throw a RangeError instead
+     *
+     * The default is `'compatible'`.
+     *
+     * */
+    disambiguation?: 'compatible' | 'earlier' | 'later' | 'reject';
+  };
+
+  type OffsetDisambiguationOptions = {
+    /**
+     * Time zone definitions can change. If an application stores data about
+     * events in the future, then stored data about future events may become
+     * ambiguous, for example if a country permanently abolishes DST. The
+     * `offset` option controls this unusual case.
+     *
+     * - `'use'` always uses the offset (if it's provided) to calculate the
+     *   instant. This ensures that the result will match the instant that was
+     *   originally stored, even if local clock time is different.
+     * - `'prefer'` uses the offset if it's valid for the date/time in this time
+     *   zone, but if it's not valid then the time zone will be used as a
+     *   fallback to calculate the instant.
+     * - `'ignore'` will disregard any provided offset. Instead, the time zone
+     *    and date/time value are used to calculate the instant. This will keep
+     *    local clock time unchanged but may result in a different real-world
+     *    instant.
+     * - `'reject'` acts like `'prefer'`, except it will throw a RangeError if
+     *   the offset is not valid for the given time zone identifier and
+     *   date/time value.
+     *
+     * If the ISO string ends in 'Z' then this option is ignored because there
+     * is no possibility of ambiguity.
+     *
+     * If a time zone offset is not present in the input, then this option is
+     * ignored because the time zone will always be used to calculate the
+     * offset.
+     *
+     * If the offset is not used, and if the date/time and time zone don't
+     * uniquely identify a single instant, then the `disambiguation` option will
+     * be used to choose the correct instant. However, if the offset is used
+     * then the `disambiguation` option will be ignored.
+     */
+    offset?: 'use' | 'prefer' | 'ignore' | 'reject';
+  };
+
+  export type ZonedDateTimeAssignmentOptions = Partial<
+    AssignmentOptions & ToInstantOptions & OffsetDisambiguationOptions
+  >;
+
+  /**
+   * Options for arithmetic operations like `add()` and `subtract()`
+   * */
+  export type ArithmeticOptions = {
+    /**
+     * Controls handling of out-of-range arithmetic results.
+     *
+     * If a result is out of range, then `'constrain'` will clamp the result to
+     * the allowed range, while `'reject'` will throw a RangeError.
+     *
+     * The default is `'constrain'`.
+     */
+    overflow?: 'constrain' | 'reject';
+  };
+
+  export type DateUnit = 'year' | 'month' | 'week' | 'day';
+  export type TimeUnit =
+    | 'hour'
+    | 'minute'
+    | 'second'
+    | 'millisecond'
+    | 'microsecond'
+    | 'nanosecond';
+  export type DateTimeUnit = DateUnit | TimeUnit;
+
+  /**
+   * When the name of a unit is provided to a Temporal API as a string, it is
+   * usually singular, e.g. 'day' or 'hour'. But plural unit names like 'days'
+   * or 'hours' are aso accepted too.
+   * */
+  export type PluralUnit<T extends DateTimeUnit> = {
+    year: 'years';
+    month: 'months';
+    week: 'weeks';
+    day: 'days';
+    hour: 'hours';
+    minute: 'minutes';
+    second: 'seconds';
+    millisecond: 'milliseconds';
+    microsecond: 'microseconds';
+    nanosecond: 'nanoseconds';
+  }[T];
+
+  export type LargestUnit<T extends DateTimeUnit> = 'auto' | T | PluralUnit<T>;
+  export type SmallestUnit<T extends DateTimeUnit> = T | PluralUnit<T>;
+  export type TotalUnit<T extends DateTimeUnit> = T | PluralUnit<T>;
+
+  /**
+   * Options for outputting precision in toString() on types with seconds
+   */
+  export type ToStringPrecisionOptions = {
+    fractionalSecondDigits?: 'auto' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+    smallestUnit?: SmallestUnit<
+      'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'
+    >;
+
+    /**
+     * Controls how rounding is performed:
+     * - `halfExpand`: Round to the nearest of the values allowed by
+     *   `roundingIncrement` and `smallestUnit`. When there is a tie, round up.
+     *   This mode is the default.
+     * - `ceil`: Always round up, towards the end of time.
+     * - `trunc`: Always round down, towards the beginning of time.
+     * - `floor`: Also round down, towards the beginning of time. This mode acts
+     *   the same as `trunc`, but it's included for consistency with
+     *   `Temporal.Duration.round()` where negative values are allowed and
+     *   `trunc` rounds towards zero, unlike `floor` which rounds towards
+     *   negative infinity which is usually unexpected. For this reason, `trunc`
+     *   is recommended for most use cases.
+     */
+    roundingMode?: RoundingMode;
+  };
+
+  export type ShowCalendarOption = {
+    calendarName?: 'auto' | 'always' | 'never' | 'critical';
+  };
+
+  export type CalendarTypeToStringOptions = Partial<
+    ToStringPrecisionOptions & ShowCalendarOption
+  >;
+
+  export type ZonedDateTimeToStringOptions = Partial<
+    CalendarTypeToStringOptions & {
+      timeZoneName?: 'auto' | 'never' | 'critical';
+      offset?: 'auto' | 'never';
+    }
+  >;
+
+  export type InstantToStringOptions = Partial<
+    ToStringPrecisionOptions & {
+      timeZone: TimeZoneLike;
+    }
+  >;
+
+  /**
+   * Options to control the result of `until()` and `since()` methods in
+   * `Temporal` types.
+   */
+  export interface DifferenceOptions<T extends DateTimeUnit> {
+    /**
+     * The unit to round to. For example, to round to the nearest minute, use
+     * `smallestUnit: 'minute'`. This property is optional for `until()` and
+     * `since()`, because those methods default behavior is not to round.
+     * However, the same property is required for `round()`.
+     */
+    smallestUnit?: SmallestUnit<T>;
+
+    /**
+     * The largest unit to allow in the resulting `Temporal.Duration` object.
+     *
+     * Larger units will be "balanced" into smaller units. For example, if
+     * `largestUnit` is `'minute'` then a two-hour duration will be output as a
+     * 120-minute duration.
+     *
+     * Valid values may include `'year'`, `'month'`, `'week'`, `'day'`,
+     * `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`,
+     * `'nanosecond'` and `'auto'`, although some types may throw an exception
+     * if a value is used that would produce an invalid result. For example,
+     * `hours` is not accepted by `Temporal.PlainDate.prototype.since()`.
+     *
+     * The default is always `'auto'`, though the meaning of this depends on the
+     * type being used.
+     */
+    largestUnit?: LargestUnit<T>;
+
+    /**
+     * Allows rounding to an integer number of units. For example, to round to
+     * increments of a half hour, use `{ smallestUnit: 'minute',
+     * roundingIncrement: 30 }`.
+     */
+    roundingIncrement?: number;
+
+    /**
+     * Controls how rounding is performed:
+     * - `halfExpand`: Round to the nearest of the values allowed by
+     *   `roundingIncrement` and `smallestUnit`. When there is a tie, round away
+     *   from zero like `ceil` for positive durations and like `floor` for
+     *   negative durations.
+     * - `ceil`: Always round up, towards the end of time.
+     * - `trunc`: Always round down, towards the beginning of time. This mode is
+     *   the default.
+     * - `floor`: Also round down, towards the beginning of time. This mode acts
+     *   the same as `trunc`, but it's included for consistency with
+     *   `Temporal.Duration.round()` where negative values are allowed and
+     *   `trunc` rounds towards zero, unlike `floor` which rounds towards
+     *   negative infinity which is usually unexpected. For this reason, `trunc`
+     *   is recommended for most use cases.
+     */
+    roundingMode?: RoundingMode;
+  }
+
+  /**
+   * `round` methods take one required parameter. If a string is provided, the
+   * resulting `Temporal.Duration` object will be rounded to that unit. If an
+   * object is provided, its `smallestUnit` property is required while other
+   * properties are optional. A string is treated the same as an object whose
+   * `smallestUnit` property value is that string.
+   */
+  export type RoundTo<T extends DateTimeUnit> =
+    | SmallestUnit<T>
+    | {
+        /**
+         * The unit to round to. For example, to round to the nearest minute,
+         * use `smallestUnit: 'minute'`. This option is required. Note that the
+         * same-named property is optional when passed to `until` or `since`
+         * methods, because those methods do no rounding by default.
+         */
+        smallestUnit: SmallestUnit<T>;
+
+        /**
+         * Allows rounding to an integer number of units. For example, to round to
+         * increments of a half hour, use `{ smallestUnit: 'minute',
+         * roundingIncrement: 30 }`.
+         */
+        roundingIncrement?: number;
+
+        /**
+         * Controls how rounding is performed:
+         * - `halfExpand`: Round to the nearest of the values allowed by
+         *   `roundingIncrement` and `smallestUnit`. When there is a tie, round up.
+         *   This mode is the default.
+         * - `ceil`: Always round up, towards the end of time.
+         * - `trunc`: Always round down, towards the beginning of time.
+         * - `floor`: Also round down, towards the beginning of time. This mode acts
+         *   the same as `trunc`, but it's included for consistency with
+         *   `Temporal.Duration.round()` where negative values are allowed and
+         *   `trunc` rounds towards zero, unlike `floor` which rounds towards
+         *   negative infinity which is usually unexpected. For this reason, `trunc`
+         *   is recommended for most use cases.
+         */
+        roundingMode?: RoundingMode;
+      };
+
+  /**
+   * The `round` method of the `Temporal.Duration` accepts one required
+   * parameter. If a string is provided, the resulting `Temporal.Duration`
+   * object will be rounded to that unit. If an object is provided, the
+   * `smallestUnit` and/or `largestUnit` property is required, while other
+   * properties are optional. A string parameter is treated the same as an
+   * object whose `smallestUnit` property value is that string.
+   */
+  export type DurationRoundTo =
+    | SmallestUnit<DateTimeUnit>
+    | ((
+        | {
+            /**
+             * The unit to round to. For example, to round to the nearest
+             * minute, use `smallestUnit: 'minute'`. This property is normally
+             * required, but is optional if `largestUnit` is provided and not
+             * undefined.
+             */
+            smallestUnit: SmallestUnit<DateTimeUnit>;
+
+            /**
+             * The largest unit to allow in the resulting `Temporal.Duration`
+             * object.
+             *
+             * Larger units will be "balanced" into smaller units. For example,
+             * if `largestUnit` is `'minute'` then a two-hour duration will be
+             * output as a 120-minute duration.
+             *
+             * Valid values include `'year'`, `'month'`, `'week'`, `'day'`,
+             * `'hour'`, `'minute'`, `'second'`, `'millisecond'`,
+             * `'microsecond'`, `'nanosecond'` and `'auto'`.
+             *
+             * The default is `'auto'`, which means "the largest nonzero unit in
+             * the input duration". This default prevents expanding durations to
+             * larger units unless the caller opts into this behavior.
+             *
+             * If `smallestUnit` is larger, then `smallestUnit` will be used as
+             * `largestUnit`, superseding a caller-supplied or default value.
+             */
+            largestUnit?: LargestUnit<DateTimeUnit>;
+          }
+        | {
+            /**
+             * The unit to round to. For example, to round to the nearest
+             * minute, use `smallestUnit: 'minute'`. This property is normally
+             * required, but is optional if `largestUnit` is provided and not
+             * undefined.
+             */
+            smallestUnit?: SmallestUnit<DateTimeUnit>;
+
+            /**
+             * The largest unit to allow in the resulting `Temporal.Duration`
+             * object.
+             *
+             * Larger units will be "balanced" into smaller units. For example,
+             * if `largestUnit` is `'minute'` then a two-hour duration will be
+             * output as a 120-minute duration.
+             *
+             * Valid values include `'year'`, `'month'`, `'week'`, `'day'`,
+             * `'hour'`, `'minute'`, `'second'`, `'millisecond'`,
+             * `'microsecond'`, `'nanosecond'` and `'auto'`.
+             *
+             * The default is `'auto'`, which means "the largest nonzero unit in
+             * the input duration". This default prevents expanding durations to
+             * larger units unless the caller opts into this behavior.
+             *
+             * If `smallestUnit` is larger, then `smallestUnit` will be used as
+             * `largestUnit`, superseding a caller-supplied or default value.
+             */
+            largestUnit: LargestUnit<DateTimeUnit>;
+          }
+      ) & {
+        /**
+         * Allows rounding to an integer number of units. For example, to round
+         * to increments of a half hour, use `{ smallestUnit: 'minute',
+         * roundingIncrement: 30 }`.
+         */
+        roundingIncrement?: number;
+
+        /**
+         * Controls how rounding is performed:
+         * - `halfExpand`: Round to the nearest of the values allowed by
+         *   `roundingIncrement` and `smallestUnit`. When there is a tie, round
+         *   away from zero like `ceil` for positive durations and like `floor`
+         *   for negative durations. This mode is the default.
+         * - `ceil`: Always round towards positive infinity. For negative
+         *   durations this option will decrease the absolute value of the
+         *   duration which may be unexpected. To round away from zero, use
+         *   `ceil` for positive durations and `floor` for negative durations.
+         * - `trunc`: Always round down towards zero.
+         * - `floor`: Always round towards negative infinity. This mode acts the
+         *   same as `trunc` for positive durations but for negative durations
+         *   it will increase the absolute value of the result which may be
+         *   unexpected. For this reason, `trunc` is recommended for most "round
+         *   down" use cases.
+         */
+        roundingMode?: RoundingMode;
+
+        /**
+         * The starting point to use for rounding and conversions when
+         * variable-length units (years, months, weeks depending on the
+         * calendar) are involved. This option is required if any of the
+         * following are true:
+         * - `unit` is `'week'` or larger units
+         * - `this` has a nonzero value for `weeks` or larger units
+         *
+         * This value must be either a `Temporal.PlainDateTime`, a
+         * `Temporal.ZonedDateTime`, or a string or object value that can be
+         * passed to `from()` of those types. Examples:
+         * - `'2020-01'01T00:00-08:00[America/Los_Angeles]'`
+         * - `'2020-01'01'`
+         * - `Temporal.PlainDate.from('2020-01-01')`
+         *
+         * `Temporal.ZonedDateTime` will be tried first because it's more
+         * specific, with `Temporal.PlainDateTime` as a fallback.
+         *
+         * If the value resolves to a `Temporal.ZonedDateTime`, then operation
+         * will adjust for DST and other time zone transitions. Otherwise
+         * (including if this option is omitted), then the operation will ignore
+         * time zone transitions and all days will be assumed to be 24 hours
+         * long.
+         */
+        relativeTo?:
+          | Temporal.PlainDateTime
+          | Temporal.ZonedDateTime
+          | PlainDateTimeLike
+          | ZonedDateTimeLike
+          | string;
+      });
+
+  /**
+   * Options to control behavior of `Duration.prototype.total()`
+   */
+  export type DurationTotalOf =
+    | TotalUnit<DateTimeUnit>
+    | {
+        /**
+         * The unit to convert the duration to. This option is required.
+         */
+        unit: TotalUnit<DateTimeUnit>;
+
+        /**
+         * The starting point to use when variable-length units (years, months,
+         * weeks depending on the calendar) are involved. This option is required if
+         * any of the following are true:
+         * - `unit` is `'week'` or larger units
+         * - `this` has a nonzero value for `weeks` or larger units
+         *
+         * This value must be either a `Temporal.PlainDateTime`, a
+         * `Temporal.ZonedDateTime`, or a string or object value that can be passed
+         * to `from()` of those types. Examples:
+         * - `'2020-01'01T00:00-08:00[America/Los_Angeles]'`
+         * - `'2020-01'01'`
+         * - `Temporal.PlainDate.from('2020-01-01')`
+         *
+         * `Temporal.ZonedDateTime` will be tried first because it's more
+         * specific, with `Temporal.PlainDateTime` as a fallback.
+         *
+         * If the value resolves to a `Temporal.ZonedDateTime`, then operation will
+         * adjust for DST and other time zone transitions. Otherwise (including if
+         * this option is omitted), then the operation will ignore time zone
+         * transitions and all days will be assumed to be 24 hours long.
+         */
+        relativeTo?:
+          | Temporal.ZonedDateTime
+          | Temporal.PlainDateTime
+          | ZonedDateTimeLike
+          | PlainDateTimeLike
+          | string;
+      };
+
+  /**
+   * Options to control behavior of `Duration.compare()`, `Duration.add()`, and
+   * `Duration.subtract()`
+   */
+  export interface DurationArithmeticOptions {
+    /**
+     * The starting point to use when variable-length units (years, months,
+     * weeks depending on the calendar) are involved. This option is required if
+     * either of the durations has a nonzero value for `weeks` or larger units.
+     *
+     * This value must be either a `Temporal.PlainDateTime`, a
+     * `Temporal.ZonedDateTime`, or a string or object value that can be passed
+     * to `from()` of those types. Examples:
+     * - `'2020-01'01T00:00-08:00[America/Los_Angeles]'`
+     * - `'2020-01'01'`
+     * - `Temporal.PlainDate.from('2020-01-01')`
+     *
+     * `Temporal.ZonedDateTime` will be tried first because it's more
+     * specific, with `Temporal.PlainDateTime` as a fallback.
+     *
+     * If the value resolves to a `Temporal.ZonedDateTime`, then operation will
+     * adjust for DST and other time zone transitions. Otherwise (including if
+     * this option is omitted), then the operation will ignore time zone
+     * transitions and all days will be assumed to be 24 hours long.
+     */
+    relativeTo?:
+      | Temporal.ZonedDateTime
+      | Temporal.PlainDateTime
+      | ZonedDateTimeLike
+      | PlainDateTimeLike
+      | string;
+  }
+
+  export type DurationLike = {
+    years?: number;
+    months?: number;
+    weeks?: number;
+    days?: number;
+    hours?: number;
+    minutes?: number;
+    seconds?: number;
+    milliseconds?: number;
+    microseconds?: number;
+    nanoseconds?: number;
+  };
+
+  /**
+   *
+   * A `Temporal.Duration` represents an immutable duration of time which can be
+   * used in date/time arithmetic.
+   *
+   * See https://tc39.es/proposal-temporal/docs/duration.html for more details.
+   */
+  export class Duration {
+    static from(
+      item: Temporal.Duration | DurationLike | string,
+    ): Temporal.Duration;
+
+    static compare(
+      one: Temporal.Duration | DurationLike | string,
+      two: Temporal.Duration | DurationLike | string,
+      options?: DurationArithmeticOptions,
+    ): ComparisonResult;
+
+    constructor(
+      years?: number,
+      months?: number,
+      weeks?: number,
+      days?: number,
+      hours?: number,
+      minutes?: number,
+      seconds?: number,
+      milliseconds?: number,
+      microseconds?: number,
+      nanoseconds?: number,
+    );
+
+    readonly sign: -1 | 0 | 1;
+    readonly blank: boolean;
+    readonly years: number;
+    readonly months: number;
+    readonly weeks: number;
+    readonly days: number;
+    readonly hours: number;
+    readonly minutes: number;
+    readonly seconds: number;
+    readonly milliseconds: number;
+    readonly microseconds: number;
+    readonly nanoseconds: number;
+    negated(): Temporal.Duration;
+    abs(): Temporal.Duration;
+    with(durationLike: DurationLike): Temporal.Duration;
+    add(
+      other: Temporal.Duration | DurationLike | string,
+      options?: DurationArithmeticOptions,
+    ): Temporal.Duration;
+
+    subtract(
+      other: Temporal.Duration | DurationLike | string,
+      options?: DurationArithmeticOptions,
+    ): Temporal.Duration;
+
+    round(roundTo: DurationRoundTo): Temporal.Duration;
+    total(totalOf: DurationTotalOf): number;
+    toLocaleString(
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ): string;
+
+    toJSON(): string;
+    toString(options?: ToStringPrecisionOptions): string;
+    valueOf(): never;
+    readonly [Symbol.toStringTag]: 'Temporal.Duration';
+  }
+
+  /**
+   * A `Temporal.Instant` is an exact point in time, with a precision in
+   * nanoseconds. No time zone or calendar information is present. Therefore,
+   * `Temporal.Instant` has no concept of days, months, or even hours.
+   *
+   * For convenience of interoperability, it internally uses nanoseconds since
+   * the {@link https://en.wikipedia.org/wiki/Unix_time|Unix epoch} (midnight
+   * UTC on January 1, 1970). However, a `Temporal.Instant` can be created from
+   * any of several expressions that refer to a single point in time, including
+   * an {@link https://en.wikipedia.org/wiki/ISO_8601|ISO 8601 string} with a
+   * time zone offset such as '2020-01-23T17:04:36.491865121-08:00'.
+   *
+   * See https://tc39.es/proposal-temporal/docs/instant.html for more details.
+   */
+  export class Instant {
+    static fromEpochSeconds(epochSeconds: number): Temporal.Instant;
+    static fromEpochMilliseconds(epochMilliseconds: number): Temporal.Instant;
+    static fromEpochMicroseconds(epochMicroseconds: bigint): Temporal.Instant;
+    static fromEpochNanoseconds(epochNanoseconds: bigint): Temporal.Instant;
+    static from(item: Temporal.Instant | string): Temporal.Instant;
+    static compare(
+      one: Temporal.Instant | string,
+      two: Temporal.Instant | string,
+    ): ComparisonResult;
+
+    constructor(epochNanoseconds: bigint);
+    readonly epochSeconds: number;
+    readonly epochMilliseconds: number;
+    readonly epochMicroseconds: bigint;
+    readonly epochNanoseconds: bigint;
+    equals(other: Temporal.Instant | string): boolean;
+    add(
+      durationLike:
+        | Omit<
+            Temporal.Duration | DurationLike,
+            'years' | 'months' | 'weeks' | 'days'
+          >
+        | string,
+    ): Temporal.Instant;
+
+    subtract(
+      durationLike:
+        | Omit<
+            Temporal.Duration | DurationLike,
+            'years' | 'months' | 'weeks' | 'days'
+          >
+        | string,
+    ): Temporal.Instant;
+
+    until(
+      other: Temporal.Instant | string,
+      options?: DifferenceOptions<
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.Duration;
+
+    since(
+      other: Temporal.Instant | string,
+      options?: DifferenceOptions<
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.Duration;
+
+    round(
+      roundTo: RoundTo<
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.Instant;
+
+    toZonedDateTime(calendarAndTimeZone: {
+      timeZone: TimeZoneLike;
+      calendar: CalendarLike;
+    }): Temporal.ZonedDateTime;
+
+    toZonedDateTimeISO(tzLike: TimeZoneLike): Temporal.ZonedDateTime;
+    toLocaleString(
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ): string;
+
+    toJSON(): string;
+    toString(options?: InstantToStringOptions): string;
+    valueOf(): never;
+    readonly [Symbol.toStringTag]: 'Temporal.Instant';
+  }
+
+  type YearOrEraAndEraYear =
+    | { era: string; eraYear: number }
+    | { year: number };
+  type MonthCodeOrMonthAndYear =
+    | (YearOrEraAndEraYear & { month: number })
+    | { monthCode: string };
+  type MonthOrMonthCode = { month: number } | { monthCode: string };
+
+  export interface CalendarProtocol {
+    id: string;
+    year(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | PlainDateLike
+        | string,
+    ): number;
+    month(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | Temporal.PlainMonthDay
+        | PlainDateLike
+        | string,
+    ): number;
+    monthCode(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | Temporal.PlainMonthDay
+        | PlainDateLike
+        | string,
+    ): string;
+    day(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainMonthDay
+        | PlainDateLike
+        | string,
+    ): number;
+    era(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): string | undefined;
+    eraYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number | undefined;
+    dayOfWeek(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number;
+    dayOfYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number;
+    weekOfYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number;
+    yearOfWeek(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number;
+    daysInWeek(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number;
+    daysInMonth(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | PlainDateLike
+        | string,
+    ): number;
+    daysInYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | PlainDateLike
+        | string,
+    ): number;
+    monthsInYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | PlainDateLike
+        | string,
+    ): number;
+    inLeapYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | PlainDateLike
+        | string,
+    ): boolean;
+    dateFromFields(
+      fields: YearOrEraAndEraYear & MonthOrMonthCode & { day: number },
+      options?: AssignmentOptions,
+    ): Temporal.PlainDate;
+    yearMonthFromFields(
+      fields: YearOrEraAndEraYear & MonthOrMonthCode,
+      options?: AssignmentOptions,
+    ): Temporal.PlainYearMonth;
+    monthDayFromFields(
+      fields: MonthCodeOrMonthAndYear & { day: number },
+      options?: AssignmentOptions,
+    ): Temporal.PlainMonthDay;
+    dateAdd(
+      date: Temporal.PlainDate | PlainDateLike | string,
+      duration: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.PlainDate;
+    dateUntil(
+      one: Temporal.PlainDate | PlainDateLike | string,
+      two: Temporal.PlainDate | PlainDateLike | string,
+      options?: DifferenceOptions<'year' | 'month' | 'week' | 'day'>,
+    ): Temporal.Duration;
+    fields(fields: Iterable<string>): Iterable<string>;
+    mergeFields(
+      fields: Record<string, unknown>,
+      additionalFields: Record<string, unknown>,
+    ): Record<string, unknown>;
+    toString?(): string;
+    toJSON?(): string;
+  }
+
+  /**
+   * Any of these types can be passed to Temporal methods instead of a Temporal.Calendar.
+   * */
+  export type CalendarLike =
+    | string
+    | CalendarProtocol
+    | ZonedDateTime
+    | PlainDateTime
+    | PlainDate
+    | PlainYearMonth
+    | PlainMonthDay;
+
+  /**
+   * A `Temporal.Calendar` is a representation of a calendar system. It includes
+   * information about how many days are in each year, how many months are in
+   * each year, how many days are in each month, and how to do arithmetic in
+   * that calendar system.
+   *
+   * See https://tc39.es/proposal-temporal/docs/calendar.html for more details.
+   */
+  export class Calendar implements CalendarProtocol {
+    static from(item: CalendarLike): Temporal.Calendar | CalendarProtocol;
+    constructor(calendarIdentifier: string);
+    readonly id: string;
+    year(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | PlainDateLike
+        | string,
+    ): number;
+
+    month(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | Temporal.PlainMonthDay
+        | PlainDateLike
+        | string,
+    ): number;
+
+    monthCode(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | Temporal.PlainMonthDay
+        | PlainDateLike
+        | string,
+    ): string;
+
+    day(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainMonthDay
+        | PlainDateLike
+        | string,
+    ): number;
+
+    era(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): string | undefined;
+
+    eraYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number | undefined;
+
+    dayOfWeek(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number;
+
+    dayOfYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number;
+
+    weekOfYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number;
+
+    yearOfWeek(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number;
+
+    daysInWeek(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | PlainDateLike
+        | string,
+    ): number;
+
+    daysInMonth(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | PlainDateLike
+        | string,
+    ): number;
+
+    daysInYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | PlainDateLike
+        | string,
+    ): number;
+
+    monthsInYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | PlainDateLike
+        | string,
+    ): number;
+
+    inLeapYear(
+      date:
+        | Temporal.PlainDate
+        | Temporal.PlainDateTime
+        | Temporal.PlainYearMonth
+        | PlainDateLike
+        | string,
+    ): boolean;
+
+    dateFromFields(
+      fields: YearOrEraAndEraYear & MonthOrMonthCode & { day: number },
+      options?: AssignmentOptions,
+    ): Temporal.PlainDate;
+
+    yearMonthFromFields(
+      fields: YearOrEraAndEraYear & MonthOrMonthCode,
+      options?: AssignmentOptions,
+    ): Temporal.PlainYearMonth;
+
+    monthDayFromFields(
+      fields: MonthCodeOrMonthAndYear & { day: number },
+      options?: AssignmentOptions,
+    ): Temporal.PlainMonthDay;
+
+    dateAdd(
+      date: Temporal.PlainDate | PlainDateLike | string,
+      duration: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.PlainDate;
+
+    dateUntil(
+      one: Temporal.PlainDate | PlainDateLike | string,
+      two: Temporal.PlainDate | PlainDateLike | string,
+      options?: DifferenceOptions<'year' | 'month' | 'week' | 'day'>,
+    ): Temporal.Duration;
+
+    fields(fields: Iterable<string>): string[];
+    mergeFields(
+      fields: Record<string, unknown>,
+      additionalFields: Record<string, unknown>,
+    ): Record<string, unknown>;
+
+    toString(): string;
+    toJSON(): string;
+    readonly [Symbol.toStringTag]: 'Temporal.Calendar';
+  }
+
+  export type PlainDateLike = {
+    era?: string | undefined;
+    eraYear?: number | undefined;
+    year?: number;
+    month?: number;
+    monthCode?: string;
+    day?: number;
+    calendar?: CalendarLike;
+  };
+
+  type PlainDateISOFields = {
+    isoYear: number;
+    isoMonth: number;
+    isoDay: number;
+    calendar: string | CalendarProtocol;
+  };
+
+  /**
+   * A `Temporal.PlainDate` represents a calendar date. "Calendar date" refers to the
+   * concept of a date as expressed in everyday usage, independent of any time
+   * zone. For example, it could be used to represent an event on a calendar
+   * which happens during the whole day no matter which time zone it's happening
+   * in.
+   *
+   * See https://tc39.es/proposal-temporal/docs/date.html for more details.
+   */
+  export class PlainDate {
+    static from(
+      item: Temporal.PlainDate | PlainDateLike | string,
+      options?: AssignmentOptions,
+    ): Temporal.PlainDate;
+
+    static compare(
+      one: Temporal.PlainDate | PlainDateLike | string,
+      two: Temporal.PlainDate | PlainDateLike | string,
+    ): ComparisonResult;
+
+    constructor(
+      isoYear: number,
+      isoMonth: number,
+      isoDay: number,
+      calendar?: CalendarLike,
+    );
+
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
+    readonly year: number;
+    readonly month: number;
+    readonly monthCode: string;
+    readonly day: number;
+    readonly calendarId: string;
+    getCalendar(): CalendarProtocol;
+    readonly dayOfWeek: number;
+    readonly dayOfYear: number;
+    readonly weekOfYear: number;
+    readonly yearOfWeek: number;
+    readonly daysInWeek: number;
+    readonly daysInYear: number;
+    readonly daysInMonth: number;
+    readonly monthsInYear: number;
+    readonly inLeapYear: boolean;
+    equals(other: Temporal.PlainDate | PlainDateLike | string): boolean;
+    with(
+      dateLike: PlainDateLike,
+      options?: AssignmentOptions,
+    ): Temporal.PlainDate;
+
+    withCalendar(calendar: CalendarLike): Temporal.PlainDate;
+    add(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.PlainDate;
+
+    subtract(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.PlainDate;
+
+    until(
+      other: Temporal.PlainDate | PlainDateLike | string,
+      options?: DifferenceOptions<'year' | 'month' | 'week' | 'day'>,
+    ): Temporal.Duration;
+
+    since(
+      other: Temporal.PlainDate | PlainDateLike | string,
+      options?: DifferenceOptions<'year' | 'month' | 'week' | 'day'>,
+    ): Temporal.Duration;
+
+    toPlainDateTime(
+      temporalTime?: Temporal.PlainTime | PlainTimeLike | string,
+    ): Temporal.PlainDateTime;
+
+    toZonedDateTime(
+      timeZoneAndTime:
+        | TimeZoneProtocol
+        | string
+        | {
+            timeZone: TimeZoneLike;
+            plainTime?: Temporal.PlainTime | PlainTimeLike | string;
+          },
+    ): Temporal.ZonedDateTime;
+
+    toPlainYearMonth(): Temporal.PlainYearMonth;
+    toPlainMonthDay(): Temporal.PlainMonthDay;
+    getISOFields(): PlainDateISOFields;
+    toLocaleString(
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ): string;
+
+    toJSON(): string;
+    toString(options?: ShowCalendarOption): string;
+    valueOf(): never;
+    readonly [Symbol.toStringTag]: 'Temporal.PlainDate';
+  }
+
+  export type PlainDateTimeLike = {
+    era?: string | undefined;
+    eraYear?: number | undefined;
+    year?: number;
+    month?: number;
+    monthCode?: string;
+    day?: number;
+    hour?: number;
+    minute?: number;
+    second?: number;
+    millisecond?: number;
+    microsecond?: number;
+    nanosecond?: number;
+    calendar?: CalendarLike;
+  };
+
+  type PlainDateTimeISOFields = {
+    isoYear: number;
+    isoMonth: number;
+    isoDay: number;
+    isoHour: number;
+    isoMinute: number;
+    isoSecond: number;
+    isoMillisecond: number;
+    isoMicrosecond: number;
+    isoNanosecond: number;
+    calendar: string | CalendarProtocol;
+  };
+
+  /**
+   * A `Temporal.PlainDateTime` represents a calendar date and wall-clock time, with
+   * a precision in nanoseconds, and without any time zone. Of the Temporal
+   * classes carrying human-readable time information, it is the most general
+   * and complete one. `Temporal.PlainDate`, `Temporal.PlainTime`, `Temporal.PlainYearMonth`,
+   * and `Temporal.PlainMonthDay` all carry less information and should be used when
+   * complete information is not required.
+   *
+   * See https://tc39.es/proposal-temporal/docs/datetime.html for more details.
+   */
+  export class PlainDateTime {
+    static from(
+      item: Temporal.PlainDateTime | PlainDateTimeLike | string,
+      options?: AssignmentOptions,
+    ): Temporal.PlainDateTime;
+
+    static compare(
+      one: Temporal.PlainDateTime | PlainDateTimeLike | string,
+      two: Temporal.PlainDateTime | PlainDateTimeLike | string,
+    ): ComparisonResult;
+
+    constructor(
+      isoYear: number,
+      isoMonth: number,
+      isoDay: number,
+      hour?: number,
+      minute?: number,
+      second?: number,
+      millisecond?: number,
+      microsecond?: number,
+      nanosecond?: number,
+      calendar?: CalendarLike,
+    );
+
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
+    readonly year: number;
+    readonly month: number;
+    readonly monthCode: string;
+    readonly day: number;
+    readonly hour: number;
+    readonly minute: number;
+    readonly second: number;
+    readonly millisecond: number;
+    readonly microsecond: number;
+    readonly nanosecond: number;
+    readonly calendarId: string;
+    getCalendar(): CalendarProtocol;
+    readonly dayOfWeek: number;
+    readonly dayOfYear: number;
+    readonly weekOfYear: number;
+    readonly yearOfWeek: number;
+    readonly daysInWeek: number;
+    readonly daysInYear: number;
+    readonly daysInMonth: number;
+    readonly monthsInYear: number;
+    readonly inLeapYear: boolean;
+    equals(other: Temporal.PlainDateTime | PlainDateTimeLike | string): boolean;
+    with(
+      dateTimeLike: PlainDateTimeLike,
+      options?: AssignmentOptions,
+    ): Temporal.PlainDateTime;
+
+    withPlainTime(
+      timeLike?: Temporal.PlainTime | PlainTimeLike | string,
+    ): Temporal.PlainDateTime;
+
+    withPlainDate(
+      dateLike: Temporal.PlainDate | PlainDateLike | string,
+    ): Temporal.PlainDateTime;
+
+    withCalendar(calendar: CalendarLike): Temporal.PlainDateTime;
+    add(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.PlainDateTime;
+
+    subtract(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.PlainDateTime;
+
+    until(
+      other: Temporal.PlainDateTime | PlainDateTimeLike | string,
+      options?: DifferenceOptions<
+        | 'year'
+        | 'month'
+        | 'week'
+        | 'day'
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.Duration;
+
+    since(
+      other: Temporal.PlainDateTime | PlainDateTimeLike | string,
+      options?: DifferenceOptions<
+        | 'year'
+        | 'month'
+        | 'week'
+        | 'day'
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.Duration;
+
+    round(
+      roundTo: RoundTo<
+        | 'day'
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.PlainDateTime;
+
+    toZonedDateTime(
+      tzLike: TimeZoneLike,
+      options?: ToInstantOptions,
+    ): Temporal.ZonedDateTime;
+
+    toPlainDate(): Temporal.PlainDate;
+    toPlainYearMonth(): Temporal.PlainYearMonth;
+    toPlainMonthDay(): Temporal.PlainMonthDay;
+    toPlainTime(): Temporal.PlainTime;
+    getISOFields(): PlainDateTimeISOFields;
+    toLocaleString(
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ): string;
+
+    toJSON(): string;
+    toString(options?: CalendarTypeToStringOptions): string;
+    valueOf(): never;
+    readonly [Symbol.toStringTag]: 'Temporal.PlainDateTime';
+  }
+
+  export type PlainMonthDayLike = {
+    era?: string | undefined;
+    eraYear?: number | undefined;
+    year?: number;
+    month?: number;
+    monthCode?: string;
+    day?: number;
+    calendar?: CalendarLike;
+  };
+
+  /**
+   * A `Temporal.PlainMonthDay` represents a particular day on the calendar, but
+   * without a year. For example, it could be used to represent a yearly
+   * recurring event, like "Bastille Day is on the 14th of July."
+   *
+   * See https://tc39.es/proposal-temporal/docs/monthday.html for more details.
+   */
+  export class PlainMonthDay {
+    static from(
+      item: Temporal.PlainMonthDay | PlainMonthDayLike | string,
+      options?: AssignmentOptions,
+    ): Temporal.PlainMonthDay;
+
+    constructor(
+      isoMonth: number,
+      isoDay: number,
+      calendar?: CalendarLike,
+      referenceISOYear?: number,
+    );
+
+    readonly monthCode: string;
+    readonly day: number;
+    readonly calendarId: string;
+    getCalendar(): CalendarProtocol;
+    equals(other: Temporal.PlainMonthDay | PlainMonthDayLike | string): boolean;
+    with(
+      monthDayLike: PlainMonthDayLike,
+      options?: AssignmentOptions,
+    ): Temporal.PlainMonthDay;
+
+    toPlainDate(year: { year: number }): Temporal.PlainDate;
+    getISOFields(): PlainDateISOFields;
+    toLocaleString(
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ): string;
+
+    toJSON(): string;
+    toString(options?: ShowCalendarOption): string;
+    valueOf(): never;
+    readonly [Symbol.toStringTag]: 'Temporal.PlainMonthDay';
+  }
+
+  export type PlainTimeLike = {
+    hour?: number;
+    minute?: number;
+    second?: number;
+    millisecond?: number;
+    microsecond?: number;
+    nanosecond?: number;
+  };
+
+  type PlainTimeISOFields = {
+    isoHour: number;
+    isoMinute: number;
+    isoSecond: number;
+    isoMillisecond: number;
+    isoMicrosecond: number;
+    isoNanosecond: number;
+  };
+
+  /**
+   * A `Temporal.PlainTime` represents a wall-clock time, with a precision in
+   * nanoseconds, and without any time zone. "Wall-clock time" refers to the
+   * concept of a time as expressed in everyday usage — the time that you read
+   * off the clock on the wall. For example, it could be used to represent an
+   * event that happens daily at a certain time, no matter what time zone.
+   *
+   * `Temporal.PlainTime` refers to a time with no associated calendar date; if you
+   * need to refer to a specific time on a specific day, use
+   * `Temporal.PlainDateTime`. A `Temporal.PlainTime` can be converted into a
+   * `Temporal.PlainDateTime` by combining it with a `Temporal.PlainDate` using the
+   * `toPlainDateTime()` method.
+   *
+   * See https://tc39.es/proposal-temporal/docs/time.html for more details.
+   */
+  export class PlainTime {
+    static from(
+      item: Temporal.PlainTime | PlainTimeLike | string,
+      options?: AssignmentOptions,
+    ): Temporal.PlainTime;
+
+    static compare(
+      one: Temporal.PlainTime | PlainTimeLike | string,
+      two: Temporal.PlainTime | PlainTimeLike | string,
+    ): ComparisonResult;
+
+    constructor(
+      hour?: number,
+      minute?: number,
+      second?: number,
+      millisecond?: number,
+      microsecond?: number,
+      nanosecond?: number,
+    );
+
+    readonly hour: number;
+    readonly minute: number;
+    readonly second: number;
+    readonly millisecond: number;
+    readonly microsecond: number;
+    readonly nanosecond: number;
+    equals(other: Temporal.PlainTime | PlainTimeLike | string): boolean;
+    with(
+      timeLike: Temporal.PlainTime | PlainTimeLike,
+      options?: AssignmentOptions,
+    ): Temporal.PlainTime;
+
+    add(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.PlainTime;
+
+    subtract(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.PlainTime;
+
+    until(
+      other: Temporal.PlainTime | PlainTimeLike | string,
+      options?: DifferenceOptions<
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.Duration;
+
+    since(
+      other: Temporal.PlainTime | PlainTimeLike | string,
+      options?: DifferenceOptions<
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.Duration;
+
+    round(
+      roundTo: RoundTo<
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.PlainTime;
+
+    toPlainDateTime(
+      temporalDate: Temporal.PlainDate | PlainDateLike | string,
+    ): Temporal.PlainDateTime;
+
+    toZonedDateTime(timeZoneAndDate: {
+      timeZone: TimeZoneLike;
+      plainDate: Temporal.PlainDate | PlainDateLike | string;
+    }): Temporal.ZonedDateTime;
+
+    getISOFields(): PlainTimeISOFields;
+    toLocaleString(
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ): string;
+
+    toJSON(): string;
+    toString(options?: ToStringPrecisionOptions): string;
+    valueOf(): never;
+    readonly [Symbol.toStringTag]: 'Temporal.PlainTime';
+  }
+
+  /**
+   * A plain object implementing the protocol for a custom time zone.
+   */
+  export interface TimeZoneProtocol {
+    id: string;
+    getOffsetNanosecondsFor(instant: Temporal.Instant | string): number;
+    getOffsetStringFor?(instant: Temporal.Instant | string): string;
+    getPlainDateTimeFor?(
+      instant: Temporal.Instant | string,
+      calendar?: CalendarLike,
+    ): Temporal.PlainDateTime;
+    getInstantFor?(
+      dateTime: Temporal.PlainDateTime | PlainDateTimeLike | string,
+      options?: ToInstantOptions,
+    ): Temporal.Instant;
+    getNextTransition?(
+      startingPoint: Temporal.Instant | string,
+    ): Temporal.Instant | null;
+    getPreviousTransition?(
+      startingPoint: Temporal.Instant | string,
+    ): Temporal.Instant | null;
+    getPossibleInstantsFor(
+      dateTime: Temporal.PlainDateTime | PlainDateTimeLike | string,
+    ): Temporal.Instant[];
+    toString?(): string;
+    toJSON?(): string;
+  }
+
+  /**
+   * Any of these types can be passed to Temporal methods instead of a Temporal.TimeZone.
+   * */
+  export type TimeZoneLike = string | TimeZoneProtocol | ZonedDateTime;
+
+  /**
+   * A `Temporal.TimeZone` is a representation of a time zone: either an
+   * {@link https://www.iana.org/time-zones|IANA time zone}, including
+   * information about the time zone such as the offset between the local time
+   * and UTC at a particular time, and daylight saving time (DST) changes; or
+   * simply a particular UTC offset with no DST.
+   *
+   * `Temporal.ZonedDateTime` is the only Temporal type to contain a time zone.
+   * Other types, like `Temporal.Instant` and `Temporal.PlainDateTime`, do not
+   * contain any time zone information, and a `Temporal.TimeZone` object is
+   * required to convert between them.
+   *
+   * See https://tc39.es/proposal-temporal/docs/timezone.html for more details.
+   */
+  export class TimeZone implements TimeZoneProtocol {
+    static from(timeZone: TimeZoneLike): Temporal.TimeZone | TimeZoneProtocol;
+    constructor(timeZoneIdentifier: string);
+    readonly id: string;
+    getOffsetNanosecondsFor(instant: Temporal.Instant | string): number;
+    getOffsetStringFor(instant: Temporal.Instant | string): string;
+    getPlainDateTimeFor(
+      instant: Temporal.Instant | string,
+      calendar?: CalendarLike,
+    ): Temporal.PlainDateTime;
+
+    getInstantFor(
+      dateTime: Temporal.PlainDateTime | PlainDateTimeLike | string,
+      options?: ToInstantOptions,
+    ): Temporal.Instant;
+
+    getNextTransition(
+      startingPoint: Temporal.Instant | string,
+    ): Temporal.Instant | null;
+
+    getPreviousTransition(
+      startingPoint: Temporal.Instant | string,
+    ): Temporal.Instant | null;
+
+    getPossibleInstantsFor(
+      dateTime: Temporal.PlainDateTime | PlainDateTimeLike | string,
+    ): Temporal.Instant[];
+
+    toString(): string;
+    toJSON(): string;
+    readonly [Symbol.toStringTag]: 'Temporal.TimeZone';
+  }
+
+  export type PlainYearMonthLike = {
+    era?: string | undefined;
+    eraYear?: number | undefined;
+    year?: number;
+    month?: number;
+    monthCode?: string;
+    calendar?: CalendarLike;
+  };
+
+  /**
+   * A `Temporal.PlainYearMonth` represents a particular month on the calendar. For
+   * example, it could be used to represent a particular instance of a monthly
+   * recurring event, like "the June 2019 meeting".
+   *
+   * See https://tc39.es/proposal-temporal/docs/yearmonth.html for more details.
+   */
+  export class PlainYearMonth {
+    static from(
+      item: Temporal.PlainYearMonth | PlainYearMonthLike | string,
+      options?: AssignmentOptions,
+    ): Temporal.PlainYearMonth;
+
+    static compare(
+      one: Temporal.PlainYearMonth | PlainYearMonthLike | string,
+      two: Temporal.PlainYearMonth | PlainYearMonthLike | string,
+    ): ComparisonResult;
+
+    constructor(
+      isoYear: number,
+      isoMonth: number,
+      calendar?: CalendarLike,
+      referenceISODay?: number,
+    );
+
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
+    readonly year: number;
+    readonly month: number;
+    readonly monthCode: string;
+    readonly calendarId: string;
+    getCalendar(): CalendarProtocol;
+    readonly daysInMonth: number;
+    readonly daysInYear: number;
+    readonly monthsInYear: number;
+    readonly inLeapYear: boolean;
+    equals(
+      other: Temporal.PlainYearMonth | PlainYearMonthLike | string,
+    ): boolean;
+
+    with(
+      yearMonthLike: PlainYearMonthLike,
+      options?: AssignmentOptions,
+    ): Temporal.PlainYearMonth;
+
+    add(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.PlainYearMonth;
+
+    subtract(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.PlainYearMonth;
+
+    until(
+      other: Temporal.PlainYearMonth | PlainYearMonthLike | string,
+      options?: DifferenceOptions<'year' | 'month'>,
+    ): Temporal.Duration;
+
+    since(
+      other: Temporal.PlainYearMonth | PlainYearMonthLike | string,
+      options?: DifferenceOptions<'year' | 'month'>,
+    ): Temporal.Duration;
+
+    toPlainDate(day: { day: number }): Temporal.PlainDate;
+    getISOFields(): PlainDateISOFields;
+    toLocaleString(
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ): string;
+
+    toJSON(): string;
+    toString(options?: ShowCalendarOption): string;
+    valueOf(): never;
+    readonly [Symbol.toStringTag]: 'Temporal.PlainYearMonth';
+  }
+
+  export type ZonedDateTimeLike = {
+    era?: string | undefined;
+    eraYear?: number | undefined;
+    year?: number;
+    month?: number;
+    monthCode?: string;
+    day?: number;
+    hour?: number;
+    minute?: number;
+    second?: number;
+    millisecond?: number;
+    microsecond?: number;
+    nanosecond?: number;
+    offset?: string;
+    timeZone?: TimeZoneLike;
+    calendar?: CalendarLike;
+  };
+
+  type ZonedDateTimeISOFields = {
+    isoYear: number;
+    isoMonth: number;
+    isoDay: number;
+    isoHour: number;
+    isoMinute: number;
+    isoSecond: number;
+    isoMillisecond: number;
+    isoMicrosecond: number;
+    isoNanosecond: number;
+    offset: string;
+    timeZone: string | TimeZoneProtocol;
+    calendar: string | CalendarProtocol;
+  };
+
+  export class ZonedDateTime {
+    static from(
+      item: Temporal.ZonedDateTime | ZonedDateTimeLike | string,
+      options?: ZonedDateTimeAssignmentOptions,
+    ): ZonedDateTime;
+
+    static compare(
+      one: Temporal.ZonedDateTime | ZonedDateTimeLike | string,
+      two: Temporal.ZonedDateTime | ZonedDateTimeLike | string,
+    ): ComparisonResult;
+
+    constructor(
+      epochNanoseconds: bigint,
+      timeZone: TimeZoneLike,
+      calendar?: CalendarLike,
+    );
+
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
+    readonly year: number;
+    readonly month: number;
+    readonly monthCode: string;
+    readonly day: number;
+    readonly hour: number;
+    readonly minute: number;
+    readonly second: number;
+    readonly millisecond: number;
+    readonly microsecond: number;
+    readonly nanosecond: number;
+    readonly timeZoneId: string;
+    getTimeZone(): TimeZoneProtocol;
+    readonly calendarId: string;
+    getCalendar(): CalendarProtocol;
+    readonly dayOfWeek: number;
+    readonly dayOfYear: number;
+    readonly weekOfYear: number;
+    readonly yearOfWeek: number;
+    readonly hoursInDay: number;
+    readonly daysInWeek: number;
+    readonly daysInMonth: number;
+    readonly daysInYear: number;
+    readonly monthsInYear: number;
+    readonly inLeapYear: boolean;
+    readonly offsetNanoseconds: number;
+    readonly offset: string;
+    readonly epochSeconds: number;
+    readonly epochMilliseconds: number;
+    readonly epochMicroseconds: bigint;
+    readonly epochNanoseconds: bigint;
+    equals(other: Temporal.ZonedDateTime | ZonedDateTimeLike | string): boolean;
+    with(
+      zonedDateTimeLike: ZonedDateTimeLike,
+      options?: ZonedDateTimeAssignmentOptions,
+    ): Temporal.ZonedDateTime;
+
+    withPlainTime(
+      timeLike?: Temporal.PlainTime | PlainTimeLike | string,
+    ): Temporal.ZonedDateTime;
+
+    withPlainDate(
+      dateLike: Temporal.PlainDate | PlainDateLike | string,
+    ): Temporal.ZonedDateTime;
+
+    withCalendar(calendar: CalendarLike): Temporal.ZonedDateTime;
+    withTimeZone(timeZone: TimeZoneLike): Temporal.ZonedDateTime;
+    add(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.ZonedDateTime;
+
+    subtract(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions,
+    ): Temporal.ZonedDateTime;
+
+    until(
+      other: Temporal.ZonedDateTime | ZonedDateTimeLike | string,
+      options?: Temporal.DifferenceOptions<
+        | 'year'
+        | 'month'
+        | 'week'
+        | 'day'
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.Duration;
+
+    since(
+      other: Temporal.ZonedDateTime | ZonedDateTimeLike | string,
+      options?: Temporal.DifferenceOptions<
+        | 'year'
+        | 'month'
+        | 'week'
+        | 'day'
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.Duration;
+
+    round(
+      roundTo: RoundTo<
+        | 'day'
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+      >,
+    ): Temporal.ZonedDateTime;
+
+    startOfDay(): Temporal.ZonedDateTime;
+    toInstant(): Temporal.Instant;
+    toPlainDateTime(): Temporal.PlainDateTime;
+    toPlainDate(): Temporal.PlainDate;
+    toPlainYearMonth(): Temporal.PlainYearMonth;
+    toPlainMonthDay(): Temporal.PlainMonthDay;
+    toPlainTime(): Temporal.PlainTime;
+    getISOFields(): ZonedDateTimeISOFields;
+    toLocaleString(
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ): string;
+
+    toJSON(): string;
+    toString(options?: ZonedDateTimeToStringOptions): string;
+    valueOf(): never;
+    readonly [Symbol.toStringTag]: 'Temporal.ZonedDateTime';
+  }
+
+  /**
+   * The `Temporal.Now` object has several methods which give information about
+   * the current date, time, and time zone.
+   *
+   * See https://tc39.es/proposal-temporal/docs/now.html for more details.
+   */
+  export const Now: {
+    /**
+     * Get the exact system date and time as a `Temporal.Instant`.
+     *
+     * This method gets the current exact system time, without regard to
+     * calendar or time zone. This is a good way to get a timestamp for an
+     * event, for example. It works like the old-style JavaScript `Date.now()`,
+     * but with nanosecond precision instead of milliseconds.
+     *
+     * Note that a `Temporal.Instant` doesn't know about time zones. For the
+     * exact time in a specific time zone, use `Temporal.Now.zonedDateTimeISO`
+     * or `Temporal.Now.zonedDateTime`.
+     * */
+    instant: () => Temporal.Instant;
+
+    /**
+     * Get the current calendar date and clock time in a specific calendar and
+     * time zone.
+     *
+     * The `calendar` parameter is required. When using the ISO 8601 calendar or
+     * if you don't understand the need for or implications of a calendar, then
+     * a more ergonomic alternative to this method is
+     * `Temporal.Now.zonedDateTimeISO()`.
+     *
+     * @param {CalendarLike} [calendar] - calendar identifier, or
+     * a `Temporal.Calendar` instance, or an object implementing the calendar
+     * protocol.
+     * @param {TimeZoneLike} [tzLike] -
+     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted, the environment's
+     * current time zone will be used.
+     */
+    zonedDateTime: (
+      calendar: CalendarLike,
+      tzLike?: TimeZoneLike,
+    ) => Temporal.ZonedDateTime;
+
+    /**
+     * Get the current calendar date and clock time in a specific time zone,
+     * using the ISO 8601 calendar.
+     *
+     * @param {TimeZoneLike} [tzLike] -
+     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted, the environment's
+     * current time zone will be used.
+     */
+    zonedDateTimeISO: (tzLike?: TimeZoneLike) => Temporal.ZonedDateTime;
+
+    /**
+     * Get the current calendar date and clock time in a specific calendar and
+     * time zone.
+     *
+     * The calendar is required. When using the ISO 8601 calendar or if you
+     * don't understand the need for or implications of a calendar, then a more
+     * ergonomic alternative to this method is `Temporal.Now.plainDateTimeISO`.
+     *
+     * Note that the `Temporal.PlainDateTime` type does not persist the time zone,
+     * but retaining the time zone is required for most time-zone-related use
+     * cases. Therefore, it's usually recommended to use
+     * `Temporal.Now.zonedDateTimeISO` or `Temporal.Now.zonedDateTime` instead
+     * of this function.
+     *
+     * @param {CalendarLike} [calendar] - calendar identifier, or
+     * a `Temporal.Calendar` instance, or an object implementing the calendar
+     * protocol.
+     * @param {TimeZoneLike} [tzLike] -
+     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted,
+     * the environment's current time zone will be used.
+     */
+    plainDateTime: (
+      calendar: CalendarLike,
+      tzLike?: TimeZoneLike,
+    ) => Temporal.PlainDateTime;
+
+    /**
+     * Get the current date and clock time in a specific time zone, using the
+     * ISO 8601 calendar.
+     *
+     * Note that the `Temporal.PlainDateTime` type does not persist the time zone,
+     * but retaining the time zone is required for most time-zone-related use
+     * cases. Therefore, it's usually recommended to use
+     * `Temporal.Now.zonedDateTimeISO` instead of this function.
+     *
+     * @param {TimeZoneLike} [tzLike] -
+     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted, the environment's
+     * current time zone will be used.
+     */
+    plainDateTimeISO: (tzLike?: TimeZoneLike) => Temporal.PlainDateTime;
+
+    /**
+     * Get the current calendar date in a specific calendar and time zone.
+     *
+     * The calendar is required. When using the ISO 8601 calendar or if you
+     * don't understand the need for or implications of a calendar, then a more
+     * ergonomic alternative to this method is `Temporal.Now.plainDateISO`.
+     *
+     * @param {CalendarLike} [calendar] - calendar identifier, or
+     * a `Temporal.Calendar` instance, or an object implementing the calendar
+     * protocol.
+     * @param {TimeZoneLike} [tzLike] -
+     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted,
+     * the environment's current time zone will be used.
+     */
+    plainDate: (
+      calendar: CalendarLike,
+      tzLike?: TimeZoneLike,
+    ) => Temporal.PlainDate;
+
+    /**
+     * Get the current date in a specific time zone, using the ISO 8601
+     * calendar.
+     *
+     * @param {TimeZoneLike} [tzLike] -
+     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted, the environment's
+     * current time zone will be used.
+     */
+    plainDateISO: (tzLike?: TimeZoneLike) => Temporal.PlainDate;
+
+    /**
+     * Get the current clock time in a specific time zone, using the ISO 8601 calendar.
+     *
+     * @param {TimeZoneLike} [tzLike] -
+     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted, the environment's
+     * current time zone will be used.
+     */
+    plainTimeISO: (tzLike?: TimeZoneLike) => Temporal.PlainTime;
+
+    /**
+     * Get the identifier of the environment's current time zone.
+     *
+     * This method gets the identifier of the current system time zone. This
+     * will usually be a named
+     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone}.
+     */
+    timeZoneId: () => string;
+
+    readonly [Symbol.toStringTag]: 'Temporal.Now';
+  };
+}
+
+declare namespace Intl {
+  type Formattable =
+    | Date
+    | Temporal.Instant
+    | Temporal.ZonedDateTime
+    | Temporal.PlainDate
+    | Temporal.PlainTime
+    | Temporal.PlainDateTime
+    | Temporal.PlainYearMonth
+    | Temporal.PlainMonthDay;
+
+  interface DateTimeFormatRangePart extends globalThis.Intl.DateTimeFormatPart {
+    source: 'shared' | 'startRange' | 'endRange';
+  }
+
+  export interface DateTimeFormat extends globalThis.Intl.DateTimeFormat {
+    /**
+     * Format a date into a string according to the locale and formatting
+     * options of this `Intl.DateTimeFormat` object.
+     *
+     * @param date The date to format.
+     */
+    format(date?: Formattable | number): string;
+
+    /**
+     * Allow locale-aware formatting of strings produced by
+     * `Intl.DateTimeFormat` formatters.
+     *
+     * @param date The date to format.
+     */
+    formatToParts(
+      date?: Formattable | number,
+    ): globalThis.Intl.DateTimeFormatPart[];
+
+    /**
+     * Format a date range in the most concise way based on the locale and
+     * options provided when instantiating this `Intl.DateTimeFormat` object.
+     *
+     * @param startDate The start date of the range to format.
+     * @param endDate The start date of the range to format. Must be the same
+     * type as `startRange`.
+     */
+    formatRange<T extends Formattable>(startDate: T, endDate: T): string;
+    formatRange(startDate: Date | number, endDate: Date | number): string;
+
+    /**
+     * Allow locale-aware formatting of tokens representing each part of the
+     * formatted date range produced by `Intl.DateTimeFormat` formatters.
+     *
+     * @param startDate The start date of the range to format.
+     * @param endDate The start date of the range to format. Must be the same
+     * type as `startRange`.
+     */
+    formatRangeToParts<T extends Formattable>(
+      startDate: T,
+      endDate: T,
+    ): DateTimeFormatRangePart[];
+    formatRangeToParts(
+      startDate: Date | number,
+      endDate: Date | number,
+    ): DateTimeFormatRangePart[];
+  }
+
+  export interface DateTimeFormatOptions
+    extends Omit<
+      globalThis.Intl.DateTimeFormatOptions,
+      'timeZone' | 'calendar'
+    > {
+    calendar?: string | Temporal.CalendarProtocol;
+    timeZone?: string | Temporal.TimeZoneProtocol;
+    // TODO: remove the props below after TS lib declarations are updated
+    dayPeriod?: 'narrow' | 'short' | 'long';
+    dateStyle?: 'full' | 'long' | 'medium' | 'short';
+    timeStyle?: 'full' | 'long' | 'medium' | 'short';
+  }
+
+  export const DateTimeFormat: {
+    /**
+     * Creates `Intl.DateTimeFormat` objects that enable language-sensitive
+     * date and time formatting.
+     */
+    new (
+      locales?: string | string[],
+      options?: DateTimeFormatOptions,
+    ): DateTimeFormat;
+    (
+      locales?: string | string[],
+      options?: DateTimeFormatOptions,
+    ): DateTimeFormat;
+
+    /**
+     * Get an array containing those of the provided locales that are supported
+     * in date and time formatting without having to fall back to the runtime's
+     * default locale.
+     */
+    supportedLocalesOf(
+      locales: string | string[],
+      options?: DateTimeFormatOptions,
+    ): string[];
+  };
+}
+
+export { Intl as Intl };
+
+export const DateTimeFormat: typeof Intl.DateTimeFormat;
+
+export function toTemporalInstant(this: Date): Temporal.Instant;

--- a/website/src/components/Playground/monaco-init.ts
+++ b/website/src/components/Playground/monaco-init.ts
@@ -207,6 +207,9 @@ if (
         /* webpackChunkName: 'bignumberDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/bignumber.d.ts'
       ),
       import(
+        /* webpackChunkName: 'temporalDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/temporal.d.ts'
+      ),
+      import(
         /* webpackChunkName: 'uuidDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/uuid.d.ts'
       ),
       ...rhDeps.map(
@@ -218,8 +221,8 @@ if (
     ]).then(([mPromise, ...settles]) => {
       if (mPromise.status !== 'fulfilled' || !mPromise.value) return;
       const monaco = mPromise.value;
-      const [react, bignumber, uuid, ...rhLibs] = settles.map(result =>
-        result.status === 'fulfilled' ? result.value.default : '',
+      const [react, bignumber, temporal, uuid, ...rhLibs] = settles.map(
+        result => (result.status === 'fulfilled' ? result.value.default : ''),
       );
 
       monaco.languages.typescript.typescriptDefaults.addExtraLib(
@@ -297,11 +300,18 @@ if (
         'file:///node_modules/bignumber.js/index.d.ts',
       );
       monaco.languages.typescript.typescriptDefaults.addExtraLib(
+        `declare module "@js-temporal/polyfill" { ${temporal} }`,
+        'file:///node_modules/@js-temporal/polyfill/index.d.ts',
+      );
+      monaco.languages.typescript.typescriptDefaults.addExtraLib(
         `declare module "uuid" { ${uuid} }`,
         'file:///node_modules/@types/uuid/index.d.ts',
       );
       monaco.languages.typescript.typescriptDefaults.addExtraLib(
         `declare globals { ${react} }`,
+      );
+      monaco.languages.typescript.typescriptDefaults.addExtraLib(
+        `declare globals { export { Temporal, DateTimeFormat } from '@js-temporal/polyfill'; }`,
       );
 
       rhLibs.forEach((lib, i) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,6 +3151,7 @@ __metadata:
   dependencies:
     "@anansi/browserslist-config": ^1.4.2
     "@babel/runtime": ^7.17.0
+    "@js-temporal/polyfill": ^0.4.4
     "@types/node": ^20.0.0
   languageName: unknown
   linkType: soft
@@ -4451,6 +4452,16 @@ __metadata:
     "@jridgewell/resolve-uri": 3.1.0
     "@jridgewell/sourcemap-codec": 1.4.14
   checksum: 0572669f855260808c16fe8f78f5f1b4356463b11d3f2c7c0b5580c8ba1cbf4ae53efe9f627595830856e57dbac2325ac17eb0c3dd0ec42102e6f227cc289c02
+  languageName: node
+  linkType: hard
+
+"@js-temporal/polyfill@npm:^0.4.4":
+  version: 0.4.4
+  resolution: "@js-temporal/polyfill@npm:0.4.4"
+  dependencies:
+    jsbi: ^4.3.0
+    tslib: ^2.4.1
+  checksum: 034c00fdc1aa1a1d96f786ebe568f9f85309bcdcdf1d3fc7f7f670b43a64cafb648739e2363af950685a6d7569fe46c88ee8e28054c7d9b47199015d94a3b8a6
   languageName: node
   linkType: hard
 
@@ -12282,6 +12293,7 @@ __metadata:
     "@data-client/core": "workspace:^"
     "@data-client/endpoint": "workspace:^"
     "@data-client/normalizr": "workspace:^"
+    "@js-temporal/polyfill": ^0.4.4
     "@types/babel__core": ^7
     "@types/benchmark": 2.1.2
     "@types/react": 18.2.21
@@ -15653,6 +15665,13 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
+  languageName: node
+  linkType: hard
+
+"jsbi@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "jsbi@npm:4.3.0"
+  checksum: 27c4f178eb7fd9d1756144066fdebc62f4a0176e877f55e646e8ce84075c13551bd575a316b9959ccdcca9d5dc05a81c9907cfa09f0cfeb43c9777797e36b0e9
   languageName: node
   linkType: hard
 
@@ -21203,6 +21222,7 @@ __metadata:
     "@docusaurus/preset-classic": canary
     "@docusaurus/theme-live-codeblock": canary
     "@docusaurus/theme-mermaid": canary
+    "@js-temporal/polyfill": ^0.4.4
     "@monaco-editor/react": ^4.4.6
     "@tsconfig/docusaurus": ^2.0.0
     "@types/react": 18.2.21
@@ -22570,6 +22590,7 @@ __metadata:
     "@commitlint/config-conventional": 17.7.0
     "@data-client/react": "workspace:^"
     "@data-client/test": "workspace:^"
+    "@js-temporal/polyfill": ^0.4.4
     "@react-navigation/native": ^6.0.13
     "@react-navigation/native-stack": ^6.9.1
     "@testing-library/react": 14.0.0
@@ -24503,7 +24524,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.0":
+"tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.5.0, tslib@npm:^2.6.0":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Going forward we want to support the most canonical form of data declaration out of the box.

It's clear at this point that the trend is toward functions, not constructors. [Temporal ](https://tc39.es/proposal-temporal/)has been stage 3, and BigInt does not support constructor form. Furthermore, any constructors can easily be converted to function form, whereas the opposite is not true.

| Type             | function | constructor |
| ---------------- | -------- | --- |
| Date             | 🛑       | ✅  |
| Temporal.Instant | ✅       | 🛑  |
| Number           | ✅       | ✅  |
| BigInt           | ✅       | 🛑  |
| [BigNumber     ](https://mikemcl.github.io/bignumber.js/)| ✅       | ✅  |
| [SimpleRecord ](https://resthooks.io/rest/5.2/api/SimpleRecord)| 🛑 | ✅ |
| [Entity.fromJS](https://dataclient.io/rest/api/Entity#fromJS) | ✅ | 🛑 |

> While Date does support function form, and Temporal.Instant does support constructor form - the value they take is not ISO string, so they cannot be used in this manner.

Because of Date and SimpleRecord we [opted for constructor form in the past](https://github.com/data-client/data-client/pull/355). But since we dropped shipping SimpleRecords, and Date is no longer the future this is a great time to move to a future-proof standard. In fact, [Entities ](https://dataclient.io/rest/api/Entity)must be constructed with a static method [fromJS ](https://dataclient.io/rest/api/Entity#fromJS)- so re-introducing a Record type with fromJS would likely be the play.


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

A very simple change of removing `new` from `unvisit`.

Docs updates are more substantial:
- Include the [Temporal polyfill](https://www.npmjs.com/package/@js-temporal/polyfill) in Playground
- Update all examples to use Temporal

BREAKING: [Schema Serializers ](https://dataclient.io/rest/guides/network-transform#deserializing-fields)*must* work in function form

This means Date will no longer work like before. Possible migrations:

```ts
class Ticker extends Entity {
  trade_id = 0;
  price = 0;
  time = Temporal.Instant.fromEpochMilliseconds(0);

  pk(): string {
    return `${this.trade_id}`;
  }
  static key = 'Ticker';

  static schema = {
    price: Number,
    time: Temporal.Instant.from,
  };
}
```

or to continue using Date:

```ts
class Ticker extends Entity {
  trade_id = 0;
  price = 0;
  time = new Date(0);

  pk(): string {
    return `${this.trade_id}`;
  }
  static key = 'Ticker';

  static schema = {
    price: Number,
    time: (iso:string) => new Date(iso),
  };
}
```