### PR TITLE
fix: Published dependency range

### DIFF
--- a/.changeset/sour-dryers-reflect.md
+++ b/.changeset/sour-dryers-reflect.md
@@ -1,0 +1,11 @@
+---
+'@data-client/graphql': patch
+'@data-client/hooks': patch
+'@data-client/react': patch
+'@data-client/redux': patch
+'@data-client/core': patch
+'@data-client/rest': patch
+'@data-client/img': patch
+---
+
+Fix published dependency range

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -120,7 +120,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@data-client/normalizr": "workspace:^",
+    "@data-client/normalizr": "^0.8.0",
     "flux-standard-action": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -102,7 +102,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@data-client/endpoint": "workspace:^"
+    "@data-client/endpoint": "^0.8.0"
   },
   "devDependencies": {
     "@anansi/browserslist-config": "^1.4.2",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -73,7 +73,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@data-client/normalizr": "workspace:^"
+    "@data-client/normalizr": "^0.8.0"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -69,7 +69,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@data-client/endpoint": "workspace:^"
+    "@data-client/endpoint": "^0.8.0"
   },
   "peerDependencies": {
     "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.7.0 || ^0.8.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -124,8 +124,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@data-client/core": "workspace:^",
-    "@data-client/use-enhanced-reducer": "workspace:^"
+    "@data-client/core": "^0.8.0",
+    "@data-client/use-enhanced-reducer": "^0.1.0"
   },
   "peerDependencies": {
     "@react-navigation/native": "^6.0.0",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -106,7 +106,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@data-client/core": "workspace:^"
+    "@data-client/core": "^0.8.0"
   },
   "peerDependencies": {
     "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.7.0 || ^0.8.0",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -124,7 +124,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@data-client/endpoint": "workspace:^",
+    "@data-client/endpoint": "^0.8.0",
     "path-to-regexp": "^6.2.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3133,19 +3133,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@data-client/core@workspace:^, @data-client/core@workspace:packages/core":
+"@data-client/core@^0.8.0, @data-client/core@workspace:^, @data-client/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@data-client/core@workspace:packages/core"
   dependencies:
     "@anansi/browserslist-config": ^1.4.2
     "@babel/runtime": ^7.17.0
-    "@data-client/normalizr": "workspace:^"
+    "@data-client/normalizr": ^0.8.0
     "@types/node": ^20.0.0
     flux-standard-action: ^2.1.1
   languageName: unknown
   linkType: soft
 
-"@data-client/endpoint@workspace:^, @data-client/endpoint@workspace:packages/endpoint":
+"@data-client/endpoint@^0.8.0, @data-client/endpoint@workspace:^, @data-client/endpoint@workspace:packages/endpoint":
   version: 0.0.0-use.local
   resolution: "@data-client/endpoint@workspace:packages/endpoint"
   dependencies:
@@ -3162,7 +3162,7 @@ __metadata:
   dependencies:
     "@anansi/browserslist-config": ^1.4.2
     "@babel/runtime": ^7.17.0
-    "@data-client/endpoint": "workspace:^"
+    "@data-client/endpoint": ^0.8.0
     "@types/node": ^20.0.0
   languageName: unknown
   linkType: soft
@@ -3173,7 +3173,7 @@ __metadata:
   dependencies:
     "@anansi/browserslist-config": ^1.4.2
     "@babel/runtime": ^7.17.0
-    "@data-client/normalizr": "workspace:^"
+    "@data-client/normalizr": ^0.8.0
     "@types/node": ^20.0.0
     "@types/react": ^18.0.30
   peerDependencies:
@@ -3191,7 +3191,7 @@ __metadata:
   dependencies:
     "@anansi/browserslist-config": ^1.4.2
     "@babel/runtime": ^7.17.0
-    "@data-client/endpoint": "workspace:^"
+    "@data-client/endpoint": ^0.8.0
     "@data-client/react": "workspace:*"
     "@types/node": ^20.0.0
     "@types/react": ^18.0.30
@@ -3205,7 +3205,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@data-client/normalizr@workspace:*, @data-client/normalizr@workspace:^, @data-client/normalizr@workspace:packages/normalizr":
+"@data-client/normalizr@^0.8.0, @data-client/normalizr@workspace:*, @data-client/normalizr@workspace:^, @data-client/normalizr@workspace:packages/normalizr":
   version: 0.0.0-use.local
   resolution: "@data-client/normalizr@workspace:packages/normalizr"
   dependencies:
@@ -3222,8 +3222,8 @@ __metadata:
   dependencies:
     "@anansi/browserslist-config": ^1.4.2
     "@babel/runtime": ^7.17.0
-    "@data-client/core": "workspace:^"
-    "@data-client/use-enhanced-reducer": "workspace:^"
+    "@data-client/core": ^0.8.0
+    "@data-client/use-enhanced-reducer": ^0.1.0
     "@react-navigation/native": ^6.1.6
     "@types/node": ^20.0.0
     "@types/react": ^18.0.30
@@ -3246,7 +3246,7 @@ __metadata:
   dependencies:
     "@anansi/browserslist-config": ^1.4.2
     "@babel/runtime": ^7.17.0
-    "@data-client/core": "workspace:^"
+    "@data-client/core": ^0.8.0
     "@data-client/react": "workspace:*"
     "@types/node": ^20.0.0
     "@types/react": ^18.0.30
@@ -3268,7 +3268,7 @@ __metadata:
   dependencies:
     "@anansi/browserslist-config": ^1.4.2
     "@babel/runtime": ^7.17.0
-    "@data-client/endpoint": "workspace:^"
+    "@data-client/endpoint": ^0.8.0
     "@types/node": ^20.0.0
     "@types/path-to-regexp": ^1.7.0
     path-to-regexp: ^6.2.1
@@ -3348,7 +3348,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@data-client/use-enhanced-reducer@workspace:^, @data-client/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
+"@data-client/use-enhanced-reducer@^0.1.0, @data-client/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
   version: 0.0.0-use.local
   resolution: "@data-client/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
   dependencies:


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://github.com/changesets/changesets/issues/432 changesets doesn't work with workspace protocols currently. This means it publishes packages with incorrect version listed (keeping workspace:)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Move back to nonworkspace until this is fixed.